### PR TITLE
[DRAFT] Fix attempt: The googletag library (GPT) script is never loaded

### DIFF
--- a/tests/e2e/sentry-googletag-pubads.spec.js
+++ b/tests/e2e/sentry-googletag-pubads.spec.js
@@ -1,0 +1,52 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Google Tag Manager pubads error', () => {
+  test('should fail when pubads is not loaded but components try to use it', async ({
+    page,
+  }) => {
+    // Navigate to a page that shows ads
+    await page.goto('http://freegle-prod.localhost/')
+
+    // Wait for googletag to be initialized
+    await page.waitForTimeout(2000)
+
+    // Check that googletag exists but pubads is undefined
+    const pubadsExists = await page.evaluate(() => {
+      return (
+        typeof window.googletag !== 'undefined' &&
+        typeof window.googletag.pubads === 'function'
+      )
+    })
+
+    // This should fail because pubads() is not loaded
+    // The test expects pubads to exist, but it doesn't, proving the bug
+    expect(pubadsExists).toBe(true)
+  })
+
+  test('should reproduce the actual error when ad refresh is called', async ({
+    page,
+  }) => {
+    const errors = []
+
+    // Capture console errors
+    page.on('pageerror', (error) => {
+      errors.push(error.message)
+    })
+
+    // Navigate to page with ads
+    await page.goto('http://freegle-prod.localhost/')
+
+    // Wait for potential ad rendering and refresh (31 seconds)
+    await page.waitForTimeout(35000)
+
+    // Check if the error occurred
+    const hasError = errors.some(
+      (err) =>
+        err.includes('pubads is not a function') ||
+        err.includes('window.googletag.pubads')
+    )
+
+    // This should fail because the error should occur, proving the bug exists
+    expect(hasError).toBe(false)
+  })
+})


### PR DESCRIPTION
## Automated Fix Attempt for Sentry Issue (⚠️ Tests Failed)

**Root Cause:** The googletag library (GPT) script is never loaded (lines 689-705 in nuxt.config.ts are commented out), but components like OurPrebidDa.vue attempt to call window.googletag.pubads() at line 120 without checking if pubads exists. The initialization code (lines 520-530) creates a stub window.googletag object, but the actual GPT library that provides the pubads() function is not loaded, causing pubads to be undefined.

**Test Results:** ❌ Tests failed
```

=== tests/e2e/sentry-googletag-pubads.spec.js ===
CI environment detected - using extended timeouts
[MR] clean output dir ...

Running 2 tests using 1 worker

CI environment detected - using extended timeouts
  ✘  1 [chromium] › sentry-googletag-pubads.spec.js:4:7 › Google Tag Manager pubads error › should fail when pubads is not loaded but components try to use it (3.4s)
CI environment detected - using extended timeouts
  ✘  2 [chromium] › sentry-googletag-pubads.spec.js:4:7 › Google Tag Manager pubads error › should fail when pubads is not loaded but components try to use it (retry #1) (3.4s)
CI environment detected - using extended timeouts
  ✘  3 [chromium] › sentry-googletag-pubads.spec.js:4:7 › Google Tag Manager pubads error › should fail when pubads is not loaded but components try to use it (retry #2) (3.4s)
CI environment detected - using extended timeouts
  ✓  4 [chromium] › sentry-googletag-pubads.spec.js:26:7 › Google Tag Manager pubads error › should reproduce the actual error when ad refresh is called (36.9s)


  1) [chromium] › sentry-googletag-pubads.spec.js:4:7 › Google Tag Manager pubads error › should fail when pubads is not loaded but components try to use it 

    Error: [2mexpect([22m[31mreceived[39m[2m).[22mtoBe[2m([22m[32mexpected[39m[2m) // Object.is equality[22m

    Expected: [32mtrue[39m
    Received: [31mfalse[39m

      21 |     // This should fail because pubads() is not loaded
      22 |     // The test expects pubads to exist, but it doesn't, proving the bug
    > 23 |     expect(pubadsExists).toBe(true)
         |                          ^
      24 |   })
      25 |
      26 |   test('should reproduce the actual error when ad refresh is called', async ({

        at /app/tests/e2e/sentry-googletag-pubads.spec.js:23:26

    attachment #1: screenshot (image/png) ──────────────────────────────────────────────────────────
    test-results/sentry-googletag-pubads-Google-Tag-Manager-pub-53f93-bads-is-not-loaded-but-components-try-to-use-it-chromium/test-failed-1.png
    ────────────────────────────────────────────────────────────────────────────────────────────────

    attachment #2: video (video/webm) ──────────────────────────────────────────────────────────────
    test-results/sentry-googletag-pubads-Google-Tag-Manager-pub-53f93-bads-is-not-loaded-but-components-try-to-use-it-chromium/video.webm
    ────────────────────────────────────────────────────────────────────────────────────────────────

    attachment #3: trace (application/zip) ─────────────────────────────────────────────────────────
    test-results/sentry-googletag-pubads-Google-Tag-Manager-pub-53f93-bads-is-not-loaded-but-components-try-to-use-it-chromium/trace.zip
    Usage:

        npx playwright show-trace test-results/sentry-googletag-pubads-Google-Tag-Manager-pub-53f93-bads-is-not-loaded-but-components-try-to-use-it-chromium/trace.zip

    ────────────────────────────────────────────────────────────────────────────────────────────────

    Retry #1 ───────────────────────────────────────────────────────────────────────────────────────

    Error: [2mexpect([22m[31mreceived[39m[2m).[22mtoBe[2m([22m[32mexpected[39m[2m) // Object.is equality[22m

    Expected: [32mtrue[39m
    Received: [31mfalse[39m

      21 |     // This should fail because pubads() is not loaded
      22 |     // The test expects pubads to exist, but it doesn't, proving the bug
    > 23 |     expect(pubadsExists).toBe(true)
         |                          ^
      24 |   })
      25 |
      26 |   test('should reproduce the actual error when ad refresh is called', async ({

        at /app/tests/e2e/sentry-googletag-pubads.spec.js:23:26

    attachment #1: screenshot (image/png) ──────────────────────────────────────────────────────────
    test-results/sentry-googletag-pubads-Google-Tag-Manager-pub-53f93-bads-is-not-loaded-but-components-try-to-use-it-chromium-retry1/test-failed-1.png
    ────────────────────────────────────────────────────────────────────────────────────────────────

    attachment #2: video (video/webm) ──────────────────────────────────────────────────────────────
    test-results/sentry-googletag-pubads-Google-Tag-Manager-pub-53f93-bads-is-not-loaded-but-components-try-to-use-it-chromium-retry1/video.webm
    ────────────────────────────────────────────────────────────────────────────────────────────────

    attachment #3: trace (application/zip) ─────────────────────────────────────────────────────────
    test-results/sentry-googletag-pubads-Google-Tag-Manager-pub-53f93-bads-is-not-loaded-but-components-try-to-use-it-chromium-retry1/trace.zip
    Usage:

        npx playwright show-trace test-results/sentry-googletag-pubads-Google-Tag-Manager-pub-53f93-bads-is-not-loaded-but-components-try-to-use-it-chromium-retry1/trace.zip

    ────────────────────────────────────────────────────────────────────────────────────────────────

    Retry #2 ───────────────────────────────────────────────────────────────────────────────────────

    Error: [2mexpect([22m[31mreceived[39m[2m).[22mtoBe[2m([22m[32mexpected[39m[2m) // Object.is equality[22m

    Expected: [32mtrue[39m
    Received: [31mfalse[39m

      21 |     // This should fail because pubads() is not loaded
      22 |     // The test expects pubads to exist, but it doesn't, proving the bug
    > 23 |     expect(pubadsExists).toBe(true)
         |                          ^
      24 |   })
      25 |
      26 |   test('should reproduce the actual error when ad refresh is called', async ({

        at /app/tests/e2e/sentry-googletag-pubads.spec.js:23:26

    attachment #1: screenshot (image/png) ──────────────────────────────────────────────────────────
    test-results/sentry-googletag-pubads-Google-Tag-Manager-pub-53f93-bads-is-not-loaded-but-components-try-to-use-it-chromium-retry2/test-failed-1.png
    ────────────────────────────────────────────────────────────────────────────────────────────────

    attachment #2: video (video/webm) ──────────────────────────────────────────────────────────────
    test-results/sentry-googletag-pubads-Google-Tag-Manager-pub-53f93-bads-is-not-loaded-but-components-try-to-use-it-chromium-retry2/video.webm
    ────────────────────────────────────────────────────────────────────────────────────────────────

    attachment #3: trace (application/zip) ─────────────────────────────────────────────────────────
    test-results/sentry-googletag-pubads-Google-Tag-Manager-pub-53f93-bads-is-not-loaded-but-components-try-to-use-it-chromium-retry2/trace.zip
    Usage:

        npx playwright show-trace test-results/sentry-googletag-pubads-Google-Tag-Manager-pub-53f93-bads-is-not-loaded-but-components-try-to-use-it-chromium-retry2/trace.zip

    ────────────────────────────────────────────────────────────────────────────────────────────────

  Slow test file: [chromium] › sentry-googletag-pubads.spec.js (47.0s)
  Consider splitting slow test files to speed up parallel execution
  1 failed
    [chromium] › sentry-googletag-pubads.spec.js:4:7 › Google Tag Manager pubads error › should fail when pubads is not loaded but components try to use it 
  1 passed (50.0s)
[MR] generating report data ...
[MR] generating test report ...
[MR] Playwright Code Coverage Report
┌─────────────┬─────────────────────────┐
│ Tests       │ 2                       │
│ ├ Failed    │ 1 (50.0%)               │
│ ├ Flaky     │ 0 (0.0%)                │
│ ├ Skipped   │ 0 (0.0%)                │
│ └ Passed    │ 1 (50.0%)               │
│ Steps       │ 78                      │
│ Suites      │ 1                       │
│ ├ Projects  │ 1                       │
│ ├ Files     │ 1                       │
│ ├ Describes │ 1                       │
│ └ Shards    │ 0                       │
│ Errors      │ 3                       │
│ Retries     │ 2                       │
│ Logs        │ 0                       │
│ Attachments │ 11                      │
│ Artifacts   │ 0                       │
│ Playwright  │ v1.40.0                 │
│ Date        │ 11/17/2025, 11:51:40 AM │
│ Duration    │ 53.1s                   │
└─────────────┴─────────────────────────┘
[MR] json: monocart-report/index.json
[MR] view report: npx monocart show-report monocart-report/index.html


```

**Note:** This is an automated fix attempt. The reproducing test case was created successfully,
but the proposed fix did not pass all tests. Please review and adjust.

---
🤖 This draft PR was automatically generated by the Sentry integration system.