### PR TITLE
Use responsive image sizes for browse thumbnails

### DIFF
--- a/components/MessageSummary.vue
+++ b/components/MessageSummary.vue
@@ -31,15 +31,16 @@
     <div class="photo-area">
       <!-- Actual photo -->
       <div v-if="gotAttachments" class="photo-container">
-        <!-- Use 640x480 to match expanded view size for faster modal loading -->
+        <!-- Responsive image sizes: 200px display (400px for 2x retina), 100px landscape (200px retina) -->
         <OurUploadedImage
           v-if="message.attachments[0]?.ouruid"
           :src="message.attachments[0].ouruid"
           :modifiers="message.attachments[0].externalmods"
           alt="Item Photo"
           class="photo-image"
-          :width="640"
-          :height="480"
+          :width="400"
+          fit="inside"
+          sizes="(orientation: landscape) and (max-width: 991px) 100px, 200px"
           :preload="preload"
         />
         <NuxtPicture
@@ -50,8 +51,9 @@
           :modifiers="message.attachments[0].externalmods"
           alt="Item Photo"
           class="photo-image"
-          :width="640"
-          :height="480"
+          :width="400"
+          fit="inside"
+          sizes="(orientation: landscape) and (max-width: 991px) 100px, 200px"
           :preload="preload"
         />
         <ProxyImage
@@ -59,9 +61,9 @@
           class-name="photo-image"
           alt="Item picture"
           :src="message.attachments[0].path"
-          :width="640"
-          :height="480"
-          fit="cover"
+          :width="400"
+          fit="inside"
+          sizes="(orientation: landscape) and (max-width: 991px) 100px, 200px"
           :preload="preload"
         />
         <!-- Multi-photo indicator -->


### PR DESCRIPTION
## Summary
- Reduce max image width from 640px to 400px (sufficient for 2x retina at 200px display)
- Add `sizes` attribute for responsive srcset selection based on viewport
- Use `fit="inside"` to preserve original photo aspect ratio (CSS object-fit handles display cropping)
- Smaller images for faster mobile scrolling while maintaining quality on retina displays

## Rationale
Previously all browse thumbnails fetched 640x480 images regardless of display size. Since users scroll through many messages but rarely click to expand, optimizing for scroll performance makes more sense than pre-caching for expansion.

## Image sizes
- **Landscape mobile/tablet**: 100px display → 200px for 2x retina
- **Portrait/desktop**: 200px display → 400px for 2x retina

## Test plan
- [ ] Browse page loads correctly on mobile portrait
- [ ] Browse page loads correctly on mobile landscape
- [ ] Browse page loads correctly on desktop
- [ ] Images appear sharp on retina displays
- [ ] Network tab shows smaller image requests than before