### PR TITLE
Migrate notification seen/allSeen to v2 API

### DIFF
--- a/api/NotificationAPI.js
+++ b/api/NotificationAPI.js
@@ -12,10 +12,10 @@ export default class NotificationAPI extends BaseAPI {
   }
 
   seen(id) {
-    return this.$post('/notification', { id, action: 'Seen' })
+    return this.$postv2('/notification/seen', { id })
   }
 
   allSeen() {
-    return this.$post('/notification', { action: 'AllSeen' })
+    return this.$postv2('/notification/allseen', {})
   }
 }


### PR DESCRIPTION
## Summary
- Update NotificationAPI to use v2 endpoints for POST operations
- seen() now calls POST /notification/seen
- allSeen() now calls POST /notification/allseen

## Test plan
- [x] Verify notification dismiss works on notification dropdown
- [x] Verify "Mark all as read" works

Depends on: https://github.com/Freegle/iznik-server-go/pull/1