### PR TITLE
feat: Charity Partner landing page and badge

### DIFF
--- a/components/CharityBadge.vue
+++ b/components/CharityBadge.vue
@@ -64,11 +64,15 @@ const showModal = (e) => {
   background-color: #2563eb !important;
   display: inline-flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: 0.3rem;
+  padding: 0.3em 0.5em;
+  line-height: 1;
 }
 
 .charity-icon {
   flex-shrink: 0;
+  vertical-align: middle;
+  margin-top: -1px;
 }
 
 .size-lg {

--- a/components/CharityBadge.vue
+++ b/components/CharityBadge.vue
@@ -1,0 +1,77 @@
+<template>
+  <div class="d-inline-block">
+    <b-badge
+      v-b-tooltip="{
+        title: 'Charity Partner - click for more info',
+      }"
+      variant="primary rounded charity-partner"
+      :class="'clickme ' + 'size-' + size"
+      @click="showModal"
+    >
+      <svg
+        class="charity-icon"
+        viewBox="0 0 24 24"
+        :width="size === 'lg' ? 20 : 16"
+        :height="size === 'lg' ? 20 : 16"
+        aria-hidden="true"
+      >
+        <path
+          d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"
+          fill="currentColor"
+        />
+        <path
+          d="M9 12l2 2 4.5-4.5"
+          fill="none"
+          stroke="white"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+      </svg>
+      Charity Partner
+    </b-badge>
+    <CharityInfoModal
+      v-if="showInfoModal"
+      ref="modal"
+      @hidden="showInfoModal = false"
+    />
+  </div>
+</template>
+<script setup>
+const CharityInfoModal = defineAsyncComponent(() =>
+  import('~/components/CharityInfoModal.vue')
+)
+
+defineProps({
+  size: {
+    type: String,
+    required: false,
+    default: 'md',
+  },
+})
+
+const showInfoModal = ref(false)
+
+const showModal = (e) => {
+  e.preventDefault()
+  e.stopPropagation()
+  showInfoModal.value = true
+}
+</script>
+<style scoped lang="scss">
+.charity-partner {
+  color: white;
+  background-color: #2563eb !important;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.charity-icon {
+  flex-shrink: 0;
+}
+
+.size-lg {
+  font-size: 1.25rem;
+}
+</style>

--- a/components/CharityBadge.vue
+++ b/components/CharityBadge.vue
@@ -64,15 +64,13 @@ const showModal = (e) => {
   background-color: #2563eb !important;
   display: inline-flex;
   align-items: center;
-  gap: 0.3rem;
-  padding: 0.3em 0.5em;
-  line-height: 1;
+  gap: 0.35em;
+  padding: 0.35em 0.65em;
+  line-height: 1.2;
 }
 
 .charity-icon {
   flex-shrink: 0;
-  vertical-align: middle;
-  margin-top: -1px;
 }
 
 .size-lg {

--- a/components/CharityInfoModal.vue
+++ b/components/CharityInfoModal.vue
@@ -1,0 +1,171 @@
+<template>
+  <b-modal ref="modal" scrollable hide-header content-class="charity-modal">
+    <template #default>
+      <div class="charity-content">
+        <div class="charity-header">
+          <svg
+            class="header-icon"
+            viewBox="0 0 24 24"
+            width="48"
+            height="48"
+            aria-hidden="true"
+          >
+            <path
+              d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"
+              fill="#2563eb"
+            />
+            <path
+              d="M9 12l2 2 4.5-4.5"
+              fill="none"
+              stroke="white"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+          <h5 class="header-title">Charity Partner</h5>
+          <p class="header-subtitle">
+            Local organisations working with Freegle
+          </p>
+        </div>
+
+        <div class="charity-body">
+          <p class="intro-text">
+            This user has registered with Freegle as a charitable organisation
+            that does charitable work locally. Charity Partners are local
+            charities, community support organisations, CICs, and trusts who use
+            Freegle to help the people and communities they serve.
+          </p>
+
+          <div class="benefits-list">
+            <div class="benefit-item">
+              <v-icon icon="gift" class="benefit-icon" />
+              <span
+                >They can post WANTEDs for items their service users need</span
+              >
+            </div>
+            <div class="benefit-item">
+              <v-icon icon="bullhorn" class="benefit-icon" />
+              <span>They can promote campaigns and events locally</span>
+            </div>
+            <div class="benefit-item">
+              <v-icon icon="hands-helping" class="benefit-icon" />
+              <span>They can find new volunteers in the community</span>
+            </div>
+          </div>
+
+          <div class="info-box">
+            <v-icon icon="info-circle" class="info-icon" />
+            <span>
+              You can find out more about this organisation by viewing their
+              profile.
+            </span>
+          </div>
+        </div>
+
+        <div class="charity-footer">
+          <b-button variant="link" class="close-btn" @click="hide">
+            Close
+          </b-button>
+        </div>
+      </div>
+    </template>
+    <template #footer><span /></template>
+  </b-modal>
+</template>
+
+<script setup>
+import { useOurModal } from '~/composables/useOurModal'
+
+const { modal, hide } = useOurModal()
+</script>
+
+<style scoped lang="scss">
+@import 'assets/css/_color-vars.scss';
+
+.charity-content {
+  padding: 0;
+}
+
+.charity-header {
+  text-align: center;
+  padding: 1.5rem 1rem 1rem;
+  border-bottom: 1px solid $color-gray--lighter;
+
+  .header-icon {
+    margin-bottom: 0.75rem;
+  }
+
+  .header-title {
+    font-size: 1.25rem;
+    font-weight: 700;
+    margin: 0 0 0.25rem 0;
+    color: $color-gray--darker;
+  }
+
+  .header-subtitle {
+    font-size: 0.9rem;
+    color: var(--color-gray-600);
+    margin: 0;
+  }
+}
+
+.charity-body {
+  padding: 1.25rem;
+}
+
+.intro-text {
+  color: var(--color-gray-600);
+  margin-bottom: 1.25rem;
+  font-size: 0.9rem;
+  line-height: 1.6;
+}
+
+.benefits-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-bottom: 1.25rem;
+}
+
+.benefit-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.9rem;
+  color: $color-gray--darker;
+
+  .benefit-icon {
+    color: #2563eb;
+    flex-shrink: 0;
+    width: 1.25rem;
+  }
+}
+
+.info-box {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem;
+  background: #eff6ff;
+  font-size: 0.85rem;
+  color: $color-gray--darker;
+  border-radius: 4px;
+
+  .info-icon {
+    color: #2563eb;
+    flex-shrink: 0;
+  }
+}
+
+.charity-footer {
+  display: flex;
+  justify-content: center;
+  padding: 1rem;
+  border-top: 1px solid $color-gray--lighter;
+
+  .close-btn {
+    color: var(--color-gray-600);
+  }
+}
+</style>

--- a/pages/charity/index.vue
+++ b/pages/charity/index.vue
@@ -80,70 +80,71 @@
           </div>
         </div>
 
-        <!-- Post preview -->
+        <!-- Post preview in phone frame -->
         <div class="preview-section">
           <h2 class="section-title">What your posts will look like</h2>
           <p class="section-subtitle">
             Charity Partner posts stand out in the feed with a blue border and
             badge.
           </p>
-          <div class="preview-cards">
-            <!-- Normal post -->
-            <div class="preview-card">
-              <div class="preview-photo">
-                <img
-                  src="https://images.unsplash.com/photo-1532298229144-0ec0c57515c7?w=400&h=400&fit=crop"
-                  alt="Children's bike"
-                  class="preview-photo-img"
-                />
-                <span class="preview-tag preview-tag--offer">OFFER</span>
-                <div class="preview-overlay">
-                  <div class="preview-overlay-info">
-                    <span class="preview-overlay-location">
-                      <v-icon icon="map-marker-alt" /> 2 miles
-                    </span>
-                    <span class="preview-overlay-time">
-                      <v-icon icon="clock" /> 3h
-                    </span>
-                  </div>
-                  <div class="preview-overlay-title">
+          <div class="phone-frame">
+            <div class="phone-notch" />
+            <div class="phone-screen">
+              <div class="phone-browse-grid">
+                <!-- Normal post -->
+                <div class="browse-card">
+                  <img
+                    src="https://images.unsplash.com/photo-1532298229144-0ec0c57515c7?w=300&h=400&fit=crop"
+                    alt="Children's bike"
+                    class="browse-card-img"
+                  />
+                  <span class="browse-tag browse-tag--offer">OFFER</span>
+                  <div class="browse-title-overlay">
                     Children's bike - good condition
                   </div>
                 </div>
-              </div>
-              <div class="preview-normal-bar">
-                <span class="preview-normal-name">Jane S.</span>
-                <span class="preview-normal-meta">3 offers</span>
-              </div>
-            </div>
-            <!-- Charity Partner post -->
-            <div class="preview-card preview-card--charity">
-              <div class="preview-photo">
-                <img
-                  src="https://images.unsplash.com/photo-1489987707025-afc232f7ea0f?w=400&h=400&fit=crop"
-                  alt="Winter coats"
-                  class="preview-photo-img"
-                />
-                <span class="preview-tag preview-tag--wanted">WANTED</span>
-                <div class="preview-overlay">
-                  <div class="preview-overlay-info">
-                    <span class="preview-overlay-location">
-                      <v-icon icon="map-marker-alt" /> Wandsworth
-                    </span>
-                    <span class="preview-overlay-time">
-                      <v-icon icon="clock" /> 1h
-                    </span>
-                  </div>
-                  <div class="preview-overlay-title">
+                <!-- Charity Partner post -->
+                <div class="browse-card browse-card--charity">
+                  <img
+                    src="https://images.unsplash.com/photo-1489987707025-afc232f7ea0f?w=300&h=400&fit=crop"
+                    alt="Winter coats"
+                    class="browse-card-img"
+                  />
+                  <span class="browse-tag browse-tag--wanted">WANTED</span>
+                  <div class="browse-title-overlay">
                     Winter coats - all sizes needed
                   </div>
+                  <div class="browse-charity-strip">
+                    <CharityBadge />
+                  </div>
                 </div>
-              </div>
-              <div class="preview-charity-bar">
-                <span class="preview-charity-name">
-                  Wandsworth Community Aid
-                </span>
-                <CharityBadge />
+                <!-- Normal post -->
+                <div class="browse-card">
+                  <img
+                    src="https://images.unsplash.com/photo-1555041469-a586c61ea9bc?w=300&h=400&fit=crop"
+                    alt="Sofa"
+                    class="browse-card-img"
+                  />
+                  <span class="browse-tag browse-tag--offer">OFFER</span>
+                  <div class="browse-title-overlay">
+                    3 seater sofa - collection only
+                  </div>
+                </div>
+                <!-- Charity Partner post -->
+                <div class="browse-card browse-card--charity">
+                  <img
+                    src="https://images.unsplash.com/photo-1445205170230-053b83016050?w=300&h=400&fit=crop"
+                    alt="Clothes"
+                    class="browse-card-img"
+                  />
+                  <span class="browse-tag browse-tag--wanted">WANTED</span>
+                  <div class="browse-title-overlay">
+                    Children's clothes ages 5-8
+                  </div>
+                  <div class="browse-charity-strip">
+                    <CharityBadge />
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -488,67 +489,74 @@ $charity-blue-light: #eff6ff;
   }
 }
 
-/* Post preview */
+/* Post preview in phone frame */
 .preview-section {
   margin-bottom: 1.5rem;
-  background: white;
-  border-radius: 12px;
-  box-shadow: var(--shadow-sm);
-  padding: 1.5rem;
+  text-align: center;
 }
 
-.preview-cards {
+.phone-frame {
+  display: inline-block;
+  background: #1a1a1a;
+  border-radius: 32px;
+  padding: 12px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+  max-width: 320px;
+  width: 100%;
+  margin: 0 auto;
+}
+
+.phone-notch {
+  width: 100px;
+  height: 6px;
+  background: #333;
+  border-radius: 3px;
+  margin: 4px auto 10px;
+}
+
+.phone-screen {
+  background: $gray-100;
+  border-radius: 20px;
+  overflow: hidden;
+  padding: 6px;
+}
+
+.phone-browse-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 0.75rem;
-
-  @media (max-width: 500px) {
-    grid-template-columns: 1fr;
-    max-width: 280px;
-    margin: 0 auto;
-  }
+  gap: 4px;
 }
 
-.preview-card {
+.browse-card {
+  position: relative;
   border-radius: 0.375rem;
   overflow: hidden;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-  background: white;
-  cursor: default;
+  background: $gray-200;
+  aspect-ratio: 3 / 4;
 
   &--charity {
     border: 2px solid $charity-blue;
   }
 }
 
-.preview-photo {
-  position: relative;
-  height: 240px;
-  overflow: hidden;
-  background: $gray-200;
-}
-
-.preview-photo-img {
-  position: absolute;
-  top: 0;
-  left: 0;
+.browse-card-img {
   width: 100%;
   height: 100%;
   object-fit: cover;
   display: block;
 }
 
-.preview-tag {
+.browse-tag {
   position: absolute;
-  top: 10px;
-  left: 10px;
-  font-size: 1.1rem;
+  top: 6px;
+  left: 6px;
+  font-size: 0.6rem;
   font-weight: 700;
-  padding: 2px 8px;
-  border-radius: 0.375rem;
+  padding: 1px 5px;
+  border-radius: 3px;
   color: white;
   text-transform: uppercase;
-  z-index: 5;
+  z-index: 2;
 
   &--offer {
     background: $color-success-fg;
@@ -559,62 +567,44 @@ $charity-blue-light: #eff6ff;
   }
 }
 
-.preview-overlay {
+.browse-title-overlay {
   position: absolute;
   bottom: 0;
   left: 0;
   right: 0;
-  padding: 2rem 0.625rem 0.5rem;
+  padding: 1.5rem 6px 6px;
   background: linear-gradient(transparent, rgba(0, 0, 0, 0.7));
   color: white;
-}
-
-.preview-overlay-info {
-  display: flex;
-  gap: 0.75rem;
-  font-size: 0.75rem;
-  margin-bottom: 0.25rem;
-  opacity: 0.9;
-}
-
-.preview-overlay-title {
-  font-size: 0.95rem;
+  font-size: 0.65rem;
   font-weight: 600;
   line-height: 1.3;
+  z-index: 1;
+
+  .browse-card--charity & {
+    bottom: 22px;
+  }
 }
 
-.preview-charity-bar {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.5rem 0.625rem;
+.browse-charity-strip {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 3px 6px;
   background: $charity-blue-light;
-  flex-wrap: wrap;
-}
-
-.preview-charity-name {
-  font-size: 0.8rem;
-  font-weight: 600;
-  color: $charity-blue;
-}
-
-.preview-normal-bar {
+  z-index: 2;
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  padding: 0.5rem 0.625rem;
-  background: $gray-100;
-}
 
-.preview-normal-name {
-  font-size: 0.8rem;
-  font-weight: 600;
-  color: $color-gray--darker;
-}
+  :deep(.charity-partner) {
+    font-size: 0.5rem !important;
+    padding: 1px 4px !important;
+  }
 
-.preview-normal-meta {
-  font-size: 0.75rem;
-  color: var(--color-gray-600);
+  :deep(.charity-icon) {
+    width: 10px !important;
+    height: 10px !important;
+  }
 }
 
 /* Signup form */

--- a/pages/charity/index.vue
+++ b/pages/charity/index.vue
@@ -87,9 +87,26 @@
             Charity Partner posts stand out in the feed with a blue border and
             badge.
           </p>
-          <div class="phone-frame">
-            <div class="phone-notch" />
-            <div class="phone-screen">
+          <div class="phone-mockup">
+            <!-- Phone frame image -->
+            <img
+              src="/phone-frame.svg"
+              alt=""
+              class="phone-frame-img"
+              aria-hidden="true"
+            />
+            <!-- Screen content positioned inside the frame -->
+            <div class="phone-screen-content">
+              <!-- Freegle header bar -->
+              <div class="phone-header">
+                <svg viewBox="0 0 24 24" width="14" height="14">
+                  <path
+                    d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"
+                    fill="white"
+                  />
+                </svg>
+                <span class="phone-header-title">Browse</span>
+              </div>
               <div class="phone-browse-grid">
                 <!-- Normal post -->
                 <div class="browse-card">
@@ -112,10 +129,10 @@
                   />
                   <span class="browse-tag browse-tag--wanted">WANTED</span>
                   <div class="browse-title-overlay">
-                    Winter coats - all sizes needed
-                  </div>
-                  <div class="browse-charity-strip">
-                    <CharityBadge />
+                    <CharityBadge class="browse-charity-badge" />
+                    <div class="browse-title-text">
+                      Winter coats - all sizes needed
+                    </div>
                   </div>
                 </div>
                 <!-- Normal post -->
@@ -127,7 +144,9 @@
                   />
                   <span class="browse-tag browse-tag--offer">OFFER</span>
                   <div class="browse-title-overlay">
-                    3 seater sofa - collection only
+                    <div class="browse-title-text">
+                      3 seater sofa - collection only
+                    </div>
                   </div>
                 </div>
                 <!-- Charity Partner post -->
@@ -139,10 +158,10 @@
                   />
                   <span class="browse-tag browse-tag--wanted">WANTED</span>
                   <div class="browse-title-overlay">
-                    Children's clothes ages 5-8
-                  </div>
-                  <div class="browse-charity-strip">
-                    <CharityBadge />
+                    <CharityBadge class="browse-charity-badge" />
+                    <div class="browse-title-text">
+                      Children's clothes ages 5-8
+                    </div>
                   </div>
                 </div>
               </div>
@@ -495,36 +514,52 @@ $charity-blue-light: #eff6ff;
   text-align: center;
 }
 
-.phone-frame {
+.phone-mockup {
   display: inline-block;
-  background: #1a1a1a;
-  border-radius: 32px;
-  padding: 12px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
-  max-width: 320px;
+  position: relative;
+  max-width: 280px;
   width: 100%;
   margin: 0 auto;
 }
 
-.phone-notch {
-  width: 100px;
-  height: 6px;
-  background: #333;
-  border-radius: 3px;
-  margin: 4px auto 10px;
+.phone-frame-img {
+  display: block;
+  width: 100%;
+  height: auto;
+  position: relative;
+  z-index: 2;
+  pointer-events: none;
+  filter: drop-shadow(0 12px 40px rgba(0, 0, 0, 0.2));
 }
 
-.phone-screen {
-  background: $gray-100;
-  border-radius: 20px;
+.phone-screen-content {
+  position: absolute;
+  top: 7.9%;
+  left: 3.8%;
+  width: 92.4%;
+  bottom: 4.8%;
+  z-index: 1;
   overflow: hidden;
-  padding: 6px;
+  border-radius: 20px;
+  background: $gray-100;
+}
+
+.phone-header {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 6px 10px;
+  background: $color-green-background;
+  color: white;
+  font-size: 0.7rem;
+  font-weight: 600;
 }
 
 .phone-browse-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 4px;
+  padding: 4px;
 }
 
 .browse-card {
@@ -572,29 +607,21 @@ $charity-blue-light: #eff6ff;
   bottom: 0;
   left: 0;
   right: 0;
-  padding: 1.5rem 6px 6px;
+  padding: 2rem 6px 6px;
   background: linear-gradient(transparent, rgba(0, 0, 0, 0.7));
   color: white;
   font-size: 0.65rem;
   font-weight: 600;
   line-height: 1.3;
   z-index: 1;
-
-  .browse-card--charity & {
-    bottom: 22px;
-  }
 }
 
-.browse-charity-strip {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  padding: 3px 6px;
-  background: $charity-blue-light;
-  z-index: 2;
-  display: flex;
-  align-items: center;
+.browse-title-text {
+  margin: 0;
+}
+
+.browse-charity-badge {
+  margin-bottom: 3px;
 
   :deep(.charity-partner) {
     font-size: 0.5rem !important;

--- a/pages/charity/index.vue
+++ b/pages/charity/index.vue
@@ -99,13 +99,14 @@
             <div class="phone-screen-content">
               <!-- Freegle header bar -->
               <div class="phone-header">
-                <svg viewBox="0 0 24 24" width="14" height="14">
-                  <path
-                    d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"
-                    fill="white"
-                  />
-                </svg>
-                <span class="phone-header-title">Browse</span>
+                <img
+                  src="https://delivery.ilovefreegle.org/?filename=icon.png&w=20&output=webp&fit=inside&url=https://www.ilovefreegle.org/icon.png"
+                  alt=""
+                  width="16"
+                  height="16"
+                  class="phone-header-logo"
+                />
+                <span class="phone-header-title">Freegle</span>
               </div>
               <div class="phone-browse-grid">
                 <!-- Normal post -->
@@ -135,6 +136,21 @@
                     </div>
                   </div>
                 </div>
+                <!-- Charity Partner post -->
+                <div class="browse-card browse-card--charity">
+                  <img
+                    src="https://images.unsplash.com/photo-1445205170230-053b83016050?w=300&h=400&fit=crop"
+                    alt="Clothes"
+                    class="browse-card-img"
+                  />
+                  <span class="browse-tag browse-tag--wanted">WANTED</span>
+                  <div class="browse-title-overlay">
+                    <CharityBadge class="browse-charity-badge" />
+                    <div class="browse-title-text">
+                      Children's clothes ages 5-8
+                    </div>
+                  </div>
+                </div>
                 <!-- Normal post -->
                 <div class="browse-card">
                   <img
@@ -149,18 +165,31 @@
                     </div>
                   </div>
                 </div>
-                <!-- Charity Partner post -->
-                <div class="browse-card browse-card--charity">
+                <!-- Normal post -->
+                <div class="browse-card">
                   <img
-                    src="https://images.unsplash.com/photo-1445205170230-053b83016050?w=300&h=400&fit=crop"
-                    alt="Clothes"
+                    src="https://images.unsplash.com/photo-1533090481720-856c6e3c1fdc?w=300&h=400&fit=crop"
+                    alt="Kitchen table"
                     class="browse-card-img"
                   />
-                  <span class="browse-tag browse-tag--wanted">WANTED</span>
+                  <span class="browse-tag browse-tag--offer">OFFER</span>
                   <div class="browse-title-overlay">
-                    <CharityBadge class="browse-charity-badge" />
                     <div class="browse-title-text">
-                      Children's clothes ages 5-8
+                      Kitchen table and 4 chairs
+                    </div>
+                  </div>
+                </div>
+                <!-- Normal post -->
+                <div class="browse-card">
+                  <img
+                    src="https://images.unsplash.com/photo-1513364776144-60967b0f800f?w=300&h=400&fit=crop"
+                    alt="Art supplies"
+                    class="browse-card-img"
+                  />
+                  <span class="browse-tag browse-tag--offer">OFFER</span>
+                  <div class="browse-title-overlay">
+                    <div class="browse-title-text">
+                      Art supplies - paints and brushes
                     </div>
                   </div>
                 </div>

--- a/pages/charity/index.vue
+++ b/pages/charity/index.vue
@@ -1,0 +1,704 @@
+<template>
+  <client-only>
+    <div class="charity-page__wrapper">
+      <div class="charity-page">
+        <!-- Hero -->
+        <div class="hero">
+          <div class="hero-badge-wrapper">
+            <div class="hero-icon">
+              <svg
+                viewBox="0 0 24 24"
+                width="40"
+                height="40"
+                aria-hidden="true"
+              >
+                <path
+                  d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"
+                  fill="white"
+                />
+                <path
+                  d="M9 12l2 2 4.5-4.5"
+                  fill="none"
+                  stroke="#1e40af"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+            </div>
+          </div>
+          <h1 class="hero-title">Partner with Freegle</h1>
+          <p class="hero-subtitle">
+            Your local Freegle community is a great place to ask for items,
+            promote your campaigns, find new volunteers and advertise events.
+          </p>
+          <p class="hero-cta-text">
+            Sign up as a <strong>Charity Partner</strong> and stand out to
+            thousands of local freeglers.
+          </p>
+          <a href="#signup" class="hero-cta-btn">
+            <v-icon icon="arrow-down" class="me-2" />
+            Register your organisation
+          </a>
+        </div>
+
+        <!-- Benefits -->
+        <div class="benefits">
+          <h2 class="section-title">Why become a Charity Partner?</h2>
+          <div class="benefits-grid">
+            <div class="benefit-card">
+              <div class="benefit-icon-circle benefit-icon-circle--blue">
+                <v-icon icon="heart" />
+              </div>
+              <h3>Stand out in the community</h3>
+              <p>
+                Your posts are highlighted with a distinctive
+                <CharityBadge /> badge and blue border, so freeglers immediately
+                know you're a trusted local organisation.
+              </p>
+            </div>
+            <div class="benefit-card">
+              <div class="benefit-icon-circle benefit-icon-circle--green">
+                <v-icon icon="gift" />
+              </div>
+              <h3>Get what your people need</h3>
+              <p>
+                Post WANTEDs for items your service users need. Local freeglers
+                are generous people who want to help their community.
+              </p>
+            </div>
+            <div class="benefit-card">
+              <div class="benefit-icon-circle benefit-icon-circle--orange">
+                <v-icon icon="hands-helping" />
+              </div>
+              <h3>Grow your network</h3>
+              <p>
+                Find new volunteers, promote campaigns and events, and connect
+                with community-minded people who care about your cause.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <!-- Post preview -->
+        <div class="preview-section">
+          <h2 class="section-title">What your posts will look like</h2>
+          <p class="section-subtitle">
+            Charity Partner posts stand out in the feed with a blue border and
+            badge.
+          </p>
+          <div class="preview-cards">
+            <!-- Normal post -->
+            <div class="preview-card">
+              <div class="preview-photo">
+                <img
+                  src="https://images.unsplash.com/photo-1532298229144-0ec0c57515c7?w=400&h=400&fit=crop"
+                  alt="Children's bike"
+                  class="preview-photo-img"
+                />
+                <span class="preview-tag preview-tag--offer">OFFER</span>
+                <div class="preview-overlay">
+                  <div class="preview-overlay-info">
+                    <span class="preview-overlay-location">
+                      <v-icon icon="map-marker-alt" /> 2 miles
+                    </span>
+                    <span class="preview-overlay-time">
+                      <v-icon icon="clock" /> 3h
+                    </span>
+                  </div>
+                  <div class="preview-overlay-title">
+                    Children's bike - good condition
+                  </div>
+                </div>
+              </div>
+              <div class="preview-normal-bar">
+                <span class="preview-normal-name">Jane S.</span>
+                <span class="preview-normal-meta">3 offers</span>
+              </div>
+            </div>
+            <!-- Charity Partner post -->
+            <div class="preview-card preview-card--charity">
+              <div class="preview-photo">
+                <img
+                  src="https://images.unsplash.com/photo-1489987707025-afc232f7ea0f?w=400&h=400&fit=crop"
+                  alt="Winter coats"
+                  class="preview-photo-img"
+                />
+                <span class="preview-tag preview-tag--wanted">WANTED</span>
+                <div class="preview-overlay">
+                  <div class="preview-overlay-info">
+                    <span class="preview-overlay-location">
+                      <v-icon icon="map-marker-alt" /> Wandsworth
+                    </span>
+                    <span class="preview-overlay-time">
+                      <v-icon icon="clock" /> 1h
+                    </span>
+                  </div>
+                  <div class="preview-overlay-title">
+                    Winter coats - all sizes needed
+                  </div>
+                </div>
+              </div>
+              <div class="preview-charity-bar">
+                <span class="preview-charity-name">
+                  Wandsworth Community Aid
+                </span>
+                <CharityBadge />
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Signup form -->
+        <div id="signup" class="signup-section">
+          <h2 class="section-title">Register as a Charity Partner</h2>
+          <p class="section-subtitle">
+            Tell us about your organisation. We'll verify your details and set
+            up your Charity Partner account.
+          </p>
+
+          <div class="signup-form">
+            <div class="form-group">
+              <label class="form-label" for="org-name">
+                Organisation name
+              </label>
+              <b-form-input
+                id="org-name"
+                v-model="form.orgName"
+                placeholder="e.g. Wandsworth Community Aid"
+              />
+            </div>
+
+            <div class="form-group">
+              <label class="form-label">Type of organisation</label>
+              <b-form-radio-group v-model="form.orgType" stacked>
+                <b-form-radio value="registered">
+                  Registered charity
+                </b-form-radio>
+                <b-form-radio value="other">
+                  Other community organisation (CIC, trust, etc.)
+                </b-form-radio>
+              </b-form-radio-group>
+            </div>
+
+            <div v-if="form.orgType === 'registered'" class="form-group">
+              <label class="form-label" for="charity-number">
+                Charity registration number
+              </label>
+              <b-form-input
+                id="charity-number"
+                v-model="form.charityNumber"
+                placeholder="e.g. 1234567"
+              />
+            </div>
+
+            <div v-if="form.orgType === 'other'" class="form-group">
+              <label class="form-label" for="org-details">
+                Tell us about your organisation's status
+              </label>
+              <b-form-textarea
+                id="org-details"
+                v-model="form.orgDetails"
+                placeholder="e.g. We are a Community Interest Company registered in..."
+                rows="2"
+              />
+            </div>
+
+            <div class="form-group">
+              <label class="form-label" for="website"> Website </label>
+              <b-form-input
+                id="website"
+                v-model="form.website"
+                placeholder="e.g. https://www.example.org"
+              />
+            </div>
+
+            <div class="form-group">
+              <label class="form-label" for="social"> Social media </label>
+              <b-form-input
+                id="social"
+                v-model="form.social"
+                placeholder="e.g. @yourorg on Facebook, Twitter, Instagram"
+              />
+            </div>
+
+            <div class="form-group">
+              <label class="form-label"> Organisation logo </label>
+              <div class="logo-upload">
+                <v-icon icon="camera" class="logo-upload-icon" />
+                <span>Upload your logo (optional)</span>
+              </div>
+            </div>
+
+            <div class="form-group">
+              <label class="form-label" for="description">
+                About your organisation
+              </label>
+              <p class="form-hint">
+                Other users are more likely to donate items if they know about
+                your work. Tell freeglers what your organisation does, where
+                you're based, and which communities you serve.
+              </p>
+              <b-form-textarea
+                id="description"
+                v-model="form.description"
+                placeholder="e.g. We provide warm clothing and household essentials to families in need across Wandsworth..."
+                rows="4"
+              />
+            </div>
+
+            <div class="form-actions">
+              <b-button variant="primary" size="lg" disabled class="submit-btn">
+                <v-icon icon="clock" class="me-1" />
+                Coming soon
+              </b-button>
+              <p class="coming-soon-text">
+                Charity Partner registration will be available soon. In the
+                meantime, please
+                <a href="mailto:partnerships@ilovefreegle.org"
+                  >contact our partnerships team</a
+                >.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <!-- Individual signup link -->
+        <div class="individual-link">
+          <p>
+            Not a charity?
+            <nuxt-link no-prefetch to="/explore">
+              Sign up as an individual
+            </nuxt-link>
+          </p>
+        </div>
+      </div>
+    </div>
+  </client-only>
+</template>
+
+<script setup>
+import { reactive } from 'vue'
+import { useRoute } from 'vue-router'
+import { buildHead } from '~/composables/useBuildHead'
+import CharityBadge from '~/components/CharityBadge.vue'
+
+const runtimeConfig = useRuntimeConfig()
+const route = useRoute()
+
+useHead(
+  buildHead(
+    route,
+    runtimeConfig,
+    'Charity Partner',
+    'Register your charitable organisation with Freegle as a Charity Partner.'
+  )
+)
+
+const form = reactive({
+  orgName: '',
+  orgType: null,
+  charityNumber: '',
+  orgDetails: '',
+  website: '',
+  social: '',
+  description: '',
+})
+</script>
+
+<style scoped lang="scss">
+@import 'bootstrap/scss/functions';
+@import 'bootstrap/scss/variables';
+@import 'bootstrap/scss/mixins/_breakpoints';
+@import 'assets/css/_color-vars.scss';
+
+$charity-blue: #2563eb;
+$charity-blue-light: #eff6ff;
+
+.charity-page__wrapper {
+  display: flex;
+  justify-content: center;
+  background: $gray-100;
+  min-height: 100vh;
+}
+
+.charity-page {
+  width: 100%;
+  max-width: 800px;
+  padding: 1rem;
+
+  @include media-breakpoint-up(md) {
+    padding: 1.5rem;
+  }
+}
+
+/* Hero */
+.hero {
+  text-align: center;
+  padding: 2.5rem 1.5rem;
+  background: white;
+  border-radius: 12px;
+  box-shadow: var(--shadow-sm);
+  margin-bottom: 1.5rem;
+  border-top: 4px solid $charity-blue;
+
+  @include media-breakpoint-up(md) {
+    padding: 3rem 2rem;
+  }
+}
+
+.hero-badge-wrapper {
+  margin-bottom: 1rem;
+}
+
+.hero-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  background: $charity-blue;
+}
+
+.hero-title {
+  font-size: 2rem;
+  font-weight: 700;
+  color: $color-gray--darker;
+  margin: 0 0 0.75rem;
+
+  @include media-breakpoint-up(md) {
+    font-size: 2.25rem;
+  }
+}
+
+.hero-subtitle {
+  font-size: 1.05rem;
+  line-height: 1.6;
+  max-width: 550px;
+  margin: 0 auto 0.5rem;
+  color: var(--color-gray-600);
+}
+
+.hero-cta-text {
+  font-size: 1.05rem;
+  margin: 0 auto 1.25rem;
+  max-width: 550px;
+  color: $color-gray--darker;
+}
+
+.hero-cta-btn {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.75rem 1.75rem;
+  background: $charity-blue;
+  color: white;
+  font-weight: 600;
+  font-size: 1rem;
+  border-radius: 8px;
+  text-decoration: none;
+  transition: transform 0.15s, box-shadow 0.15s;
+
+  &:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(37, 99, 235, 0.3);
+    color: white;
+    text-decoration: none;
+  }
+}
+
+/* Benefits */
+.benefits {
+  margin-bottom: 1.5rem;
+}
+
+.section-title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: $color-gray--darker;
+  margin-bottom: 0.5rem;
+}
+
+.section-subtitle {
+  font-size: 0.9rem;
+  color: var(--color-gray-600);
+  margin-bottom: 1rem;
+}
+
+.benefits-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+
+  @include media-breakpoint-up(md) {
+    grid-template-columns: 1fr 1fr 1fr;
+  }
+}
+
+.benefit-card {
+  padding: 1.5rem;
+  background: white;
+  border-radius: 12px;
+  box-shadow: var(--shadow-sm);
+  text-align: center;
+  transition: transform 0.15s, box-shadow 0.15s;
+
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
+  }
+
+  h3 {
+    font-size: 1rem;
+    font-weight: 700;
+    color: $color-gray--darker;
+    margin: 1rem 0 0.5rem;
+  }
+
+  p {
+    font-size: 0.875rem;
+    color: var(--color-gray-600);
+    line-height: 1.6;
+    margin: 0;
+  }
+}
+
+.benefit-icon-circle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  font-size: 1.5rem;
+
+  &--blue {
+    background: #eff6ff;
+    color: $charity-blue;
+  }
+
+  &--green {
+    background: #f0fdf4;
+    color: $color-success;
+  }
+
+  &--orange {
+    background: #fff7ed;
+    color: $color-orange--dark;
+  }
+}
+
+/* Post preview */
+.preview-section {
+  margin-bottom: 1.5rem;
+  background: white;
+  border-radius: 12px;
+  box-shadow: var(--shadow-sm);
+  padding: 1.5rem;
+}
+
+.preview-cards {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.75rem;
+
+  @media (max-width: 500px) {
+    grid-template-columns: 1fr;
+    max-width: 280px;
+    margin: 0 auto;
+  }
+}
+
+.preview-card {
+  border-radius: 0.375rem;
+  overflow: hidden;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  background: white;
+  cursor: default;
+
+  &--charity {
+    border: 2px solid $charity-blue;
+  }
+}
+
+.preview-photo {
+  position: relative;
+  height: 240px;
+  overflow: hidden;
+  background: $gray-200;
+}
+
+.preview-photo-img {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.preview-tag {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  font-size: 1.1rem;
+  font-weight: 700;
+  padding: 2px 8px;
+  border-radius: 0.375rem;
+  color: white;
+  text-transform: uppercase;
+  z-index: 5;
+
+  &--offer {
+    background: $color-success-fg;
+  }
+
+  &--wanted {
+    background: $color-blue--light;
+  }
+}
+
+.preview-overlay {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 2rem 0.625rem 0.5rem;
+  background: linear-gradient(transparent, rgba(0, 0, 0, 0.7));
+  color: white;
+}
+
+.preview-overlay-info {
+  display: flex;
+  gap: 0.75rem;
+  font-size: 0.75rem;
+  margin-bottom: 0.25rem;
+  opacity: 0.9;
+}
+
+.preview-overlay-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.preview-charity-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.625rem;
+  background: $charity-blue-light;
+  flex-wrap: wrap;
+}
+
+.preview-charity-name {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: $charity-blue;
+}
+
+.preview-normal-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 0.625rem;
+  background: $gray-100;
+}
+
+.preview-normal-name {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: $color-gray--darker;
+}
+
+.preview-normal-meta {
+  font-size: 0.75rem;
+  color: var(--color-gray-600);
+}
+
+/* Signup form */
+.signup-section {
+  background: white;
+  border-radius: 8px;
+  box-shadow: var(--shadow-sm);
+  padding: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+.signup-form {
+  margin-top: 1rem;
+}
+
+.form-group {
+  margin-bottom: 1.25rem;
+}
+
+.form-label {
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: $color-gray--darker;
+  margin-bottom: 0.375rem;
+  display: block;
+}
+
+.form-hint {
+  font-size: 0.8rem;
+  color: var(--color-gray-600);
+  margin-bottom: 0.5rem;
+  line-height: 1.4;
+}
+
+.logo-upload {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1.5rem;
+  border: 2px dashed $gray-300;
+  border-radius: 8px;
+  color: var(--color-gray-600);
+  font-size: 0.9rem;
+  cursor: not-allowed;
+  opacity: 0.7;
+
+  .logo-upload-icon {
+    font-size: 1.5rem;
+    color: $gray-400;
+  }
+}
+
+.form-actions {
+  text-align: center;
+  padding-top: 0.5rem;
+}
+
+.submit-btn {
+  min-width: 200px;
+}
+
+.coming-soon-text {
+  font-size: 0.85rem;
+  color: var(--color-gray-600);
+  margin-top: 0.75rem;
+
+  a {
+    color: $charity-blue;
+  }
+}
+
+/* Individual link */
+.individual-link {
+  text-align: center;
+  padding: 1rem;
+
+  p {
+    font-size: 0.9rem;
+    color: var(--color-gray-600);
+    margin: 0;
+
+    a {
+      color: $charity-blue;
+    }
+  }
+}
+</style>

--- a/public/phone-frame.svg
+++ b/public/phone-frame.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 660" fill="none">
+  <defs>
+    <mask id="screen-hole">
+      <rect width="320" height="660" fill="white"/>
+      <rect x="12" y="52" width="296" height="576" rx="28" fill="black"/>
+    </mask>
+  </defs>
+  <!-- Phone body with screen hole cut out -->
+  <rect x="2" y="2" width="316" height="656" rx="42" fill="#1a1a1c" stroke="#333" stroke-width="2" mask="url(#screen-hole)"/>
+  <!-- Inner bezel (also masked) -->
+  <rect x="6" y="6" width="308" height="648" rx="39" fill="#2c2c2e" mask="url(#screen-hole)"/>
+  <!-- Dynamic island -->
+  <rect x="115" y="18" width="90" height="24" rx="12" fill="#000"/>
+  <!-- Side buttons -->
+  <rect x="-2" y="110" width="4" height="32" rx="2" fill="#3a3a3c"/>
+  <rect x="-2" y="152" width="4" height="32" rx="2" fill="#3a3a3c"/>
+  <rect x="318" y="130" width="4" height="44" rx="2" fill="#3a3a3c"/>
+</svg>


### PR DESCRIPTION
## Summary
- New `/charity` landing page with hero section, benefits grid, post preview mockups, and inline signup form
- `CharityBadge.vue` component — blue heart+checkmark icon, clickable with info modal
- `CharityInfoModal.vue` — explains Charity Partner status and benefits
- Signup form is visual only (coming soon state) — no backend wiring yet
- Design/demo build for partnerships team review per WW3 project requirements

## Design Decisions
- **Badge colour**: Blue (#2563eb) — trust/verified feel, distinct from gold Supporter badge
- **Badge icon**: Heart with checkmark — follows platform conventions (JustGiving, GoFundMe, Facebook)
- **Post styling**: Blue border on charity partner message cards + badge next to org name
- **Normal registration**: Completely untouched

## Test plan
- [ ] Visit `/charity` page and verify all sections render
- [ ] Click Charity Partner badge to verify info modal opens
- [ ] Verify form fields display and radio buttons toggle conditional fields
- [ ] Verify "Register your organisation" button scrolls to signup section
- [ ] Verify "Sign up as an individual" links to `/explore`
- [ ] Verify "contact our partnerships team" mailto link works
- [ ] Check responsive layout on mobile breakpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)