### PR TITLE
perf(cls): fix layout shifts on browse, myposts, and chats

### DIFF
--- a/components/ChatFooter.vue
+++ b/components/ChatFooter.vue
@@ -1056,7 +1056,7 @@ onMounted(() => {
 }
 
 :deep(textarea) {
-  transition: height 1s;
+  transition: height 0.1s;
   height: v-bind(height) !important;
   max-height: calc(50vh - 120px);
   overflow-y: auto !important;

--- a/components/ChatPane.vue
+++ b/components/ChatPane.vue
@@ -5,7 +5,7 @@
       v-else-if="!id"
       class="empty-state-pane chatHolder"
       :class="{
-        stickyAdRendered,
+        allowAd,
       }"
     >
       <div class="empty-state-content">
@@ -20,7 +20,7 @@
       v-else-if="me"
       class="chatHolder"
       :class="{
-        stickyAdRendered,
+        allowAd,
         navBarHidden,
       }"
     >
@@ -196,13 +196,13 @@ import SupporterInfo from './SupporterInfo'
 import { navBarHidden } from '~/composables/useNavbar'
 import { useUserStore } from '~/stores/user'
 import { useChatStore } from '~/stores/chat'
-import { useMiscStore } from '~/stores/misc'
 import { setupChat } from '~/composables/useChat'
 import { timeago } from '~/composables/useTimeFormat'
 
 // Don't use dynamic imports because it stops us being able to scroll to the bottom after render.
 import ChatMessage from '~/components/ChatMessage.vue'
 import { useAuthStore } from '~/stores/auth'
+import { useMe } from '~/composables/useMe'
 
 const ProfileModal = defineAsyncComponent(() =>
   import('~/components/ProfileModal')
@@ -219,8 +219,8 @@ const ChatReportModal = defineAsyncComponent(() =>
 
 const chatStore = useChatStore()
 const userStore = useUserStore()
-const miscStore = useMiscStore()
 const authStore = useAuthStore()
+const { recentDonor } = useMe()
 
 const props = defineProps({
   id: { type: Number, required: true },
@@ -232,7 +232,8 @@ function resize() {
   windowHeight.value = window.innerHeight
 }
 
-const stickyAdRendered = computed(() => miscStore.stickyAdRendered)
+// Pre-reserve sticky-ad height for non-donors so chatHolder doesn't shrink when the ad renders.
+const allowAd = computed(() => !recentDonor.value)
 
 const ChatNotVisible = defineAsyncComponent(() =>
   import('~/components/ChatNotVisible.vue')
@@ -457,7 +458,6 @@ function typing() {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  transition: height 1s;
 
   height: calc(100vh - 60px);
 
@@ -469,7 +469,7 @@ function typing() {
     height: 100vh;
   }
 
-  &.stickyAdRendered {
+  &.allowAd {
     height: calc(100vh - 60px - $sticky-banner-height-mobile);
 
     @media (min-height: $mobile-tall) {
@@ -512,7 +512,7 @@ function typing() {
       height: 100dvh;
     }
 
-    &.stickyAdRendered {
+    &.allowAd {
       height: calc(100dvh - 60px - $sticky-banner-height-mobile);
 
       @media (min-height: $mobile-tall) {

--- a/components/LayoutCommon.vue
+++ b/components/LayoutCommon.vue
@@ -21,7 +21,6 @@
               'bg-white': stickyAdRendered,
             }"
           >
-            <DaDisableCTA v-if="!adRendering && stickyAdRendered" />
             <div
               class="d-flex justify-content-around w-100"
               :class="{
@@ -54,6 +53,10 @@
                 />
               </VisibleWhen>
             </div>
+            <!-- DaDisableCTA below the ad so it appears at the bottom of the sticky
+                 banner when ads render — prevents it pushing the ad content (and
+                 div.jobs-slot within it) downward, which caused CLS. -->
+            <DaDisableCTA v-if="!adRendering && stickyAdRendered" />
           </div>
         </div>
       </client-only>

--- a/components/MessageList.vue
+++ b/components/MessageList.vue
@@ -15,7 +15,6 @@
     <div
       v-if="
         initialFetchDone &&
-        !loading &&
         selectedSort === 'Unseen' &&
         showCountsUnseen &&
         me
@@ -30,11 +29,12 @@
 
     <!-- Split view: unseen messages, divider, seen messages.
          Gated on initialFetchDone to prevent CLS from divider appearing then
-         disappearing as message de-duplication changes seen/unseen split. -->
+         disappearing as message de-duplication changes seen/unseen split.
+         Loading state is handled per-ScrollGrid below — the outer template
+         must not hide once shown, as toggling it on re-fetch causes CLS. -->
     <template
       v-if="
         initialFetchDone &&
-        !loading &&
         selectedSort === 'Unseen' &&
         showCountsUnseen &&
         me

--- a/components/StoryOne.vue
+++ b/components/StoryOne.vue
@@ -214,11 +214,13 @@ async function unlove() {
 
 .story-card__image {
   margin-bottom: 1rem;
+  width: 250px;
+  height: 250px;
 }
 
 .story-card__photo {
-  max-height: 250px;
-  max-width: 250px;
+  width: 100%;
+  height: 100%;
   cursor: pointer;
   object-fit: cover;
 }

--- a/tests/unit/components/LayoutCommon.spec.js
+++ b/tests/unit/components/LayoutCommon.spec.js
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { ref } from 'vue'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
 
 const mockMiscStore = {
   stickyAdRendered: false,
@@ -96,6 +98,19 @@ describe('LayoutCommon', () => {
     it('shows DaDisableCTA after ad rendered', () => {
       // v-if="!adRendering && stickyAdRendered"
       expect(true).toBe(true)
+    })
+
+    it('places DaDisableCTA AFTER the ad container to prevent CLS', () => {
+      // CLS fix: DaDisableCTA must appear AFTER ExternalDa in the template.
+      // If it came before, the element appearing on ad render would push the
+      // ad content (and div.jobs-slot) downward, causing a measurable layout shift.
+      const src = readFileSync(
+        resolve(__dirname, '../../../components/LayoutCommon.vue'),
+        'utf-8'
+      )
+      const daDisableCtaPos = src.indexOf('DaDisableCTA')
+      const externalDaPos = src.indexOf('ExternalDa')
+      expect(daDisableCtaPos).toBeGreaterThan(externalDaPos)
     })
   })
 


### PR DESCRIPTION
## Summary
- Moves `DaDisableCTA` below the ad container in `LayoutCommon.vue` — previously it appeared above `ExternalDa`, so when it rendered it pushed the ad (and `div.jobs-slot`) downward, causing a measurable CLS
- Pre-reserves sticky-ad height in `ChatPane.vue` using `allowAd` (computed from `recentDonor`) instead of reacting to `stickyAdRendered` after the fact — eliminates height jump when ad loads in chats
- Reduces CSS `transition: height` in `ChatFooter.vue` from 1s to 0.1s to reduce visible shift duration
- Reserves a fixed 250×250 space for images in `StoryOne.vue` to prevent reflow when images load

Fixes Sentry issue #7372783012 (CLS 0.104–21.6 on /browse and /myposts, **15,703 events, 4,914 users** affected)

## Test plan
- Added Vitest test: `LayoutCommon > sticky ad > places DaDisableCTA AFTER the ad container to prevent CLS`
  - Reads `LayoutCommon.vue` and asserts `DaDisableCTA` appears after `ExternalDa` in the template
  - Fails on master (DaDisableCTA at position 617, ExternalDa at 925 → 617 > 925 is false)
  - Passes on this branch (DaDisableCTA at position 1829, ExternalDa at 856 → 1829 > 856 is true)
- Manual: browse to `/browse` and `/myposts` on mobile — no layout shift after ad loads