### PR TITLE
fix: spam list rejection error and missing error handling

### DIFF
--- a/modtools/components/ModMemberButton.vue
+++ b/modtools/components/ModMemberButton.vue
@@ -214,17 +214,27 @@ async function spamConfirmAction() {
 }
 
 async function spamRequestRemove() {
-  await spammerStore.requestremove({
-    id: props.spammerid,
-    userid: props.userid,
-  })
+  try {
+    await spammerStore.requestremove({
+      id: props.spammerid,
+      userid: props.userid,
+    })
+  } catch (e) {
+    console.error('spamRequestRemove failed:', e)
+    throw e
+  }
 }
 
 async function spamRemove() {
-  await spammerStore.remove({
-    id: props.spammerid,
-    userid: props.userid,
-  })
+  try {
+    await spammerStore.remove({
+      id: props.spammerid,
+      userid: props.userid,
+    })
+  } catch (e) {
+    console.error('spamRemove failed:', e)
+    throw e
+  }
 }
 
 async function spamSafelist() {
@@ -274,50 +284,55 @@ async function releaseIt() {
 }
 
 async function click(callback) {
-  if (props.approve) {
-    await approveIt()
-  } else if (props.delete) {
-    await deleteIt()
-  } else if (props.spamreport) {
-    await spamReport()
-  } else if (props.spamconfirm) {
-    await spamConfirmAction()
-  } else if (props.spamrequestremove) {
-    await spamRequestRemove()
-  } else if (props.spamremove) {
-    await spamRemove()
-  } else if (props.spamsafelist) {
-    await spamSafelist()
-  } else if (props.spamhold) {
-    await spamHold()
-  } else if (props.spamignore) {
-    // spamIgnore - not implemented in original
-  } else if (props.release) {
-    console.log('Release')
-    await releaseIt()
-  } else if (props.reviewhold) {
-    await reviewHoldIt()
-  } else if (props.reviewrelease) {
-    await reviewReleaseIt()
-  } else {
-    // We want to show a modal.
-    stdmsgId.value = null
-    stdmsgAction.value = null
+  try {
+    if (props.approve) {
+      await approveIt()
+    } else if (props.delete) {
+      await deleteIt()
+    } else if (props.spamreport) {
+      await spamReport()
+    } else if (props.spamconfirm) {
+      await spamConfirmAction()
+    } else if (props.spamrequestremove) {
+      await spamRequestRemove()
+    } else if (props.spamremove) {
+      await spamRemove()
+    } else if (props.spamsafelist) {
+      await spamSafelist()
+    } else if (props.spamhold) {
+      await spamHold()
+    } else if (props.spamignore) {
+      // spamIgnore - not implemented in original
+    } else if (props.release) {
+      console.log('Release')
+      await releaseIt()
+    } else if (props.reviewhold) {
+      await reviewHoldIt()
+    } else if (props.reviewrelease) {
+      await reviewReleaseIt()
+    } else {
+      // We want to show a modal.
+      stdmsgId.value = null
+      stdmsgAction.value = null
 
-    if (props.leave) {
-      stdmsgAction.value = 'Leave Member'
-    } else if (props.stdmsgid) {
-      // We have a standard message.  Fetch it into the store.
-      await stdmsgStore.fetch(props.stdmsgid)
-      stdmsgId.value = props.stdmsgid
+      if (props.leave) {
+        stdmsgAction.value = 'Leave Member'
+      } else if (props.stdmsgid) {
+        // We have a standard message.  Fetch it into the store.
+        await stdmsgStore.fetch(props.stdmsgid)
+        stdmsgId.value = props.stdmsgid
+      }
+
+      showStdMsgModal.value = true
+      stdmodal.value?.show()
+      await nextTick()
+      stdmodal.value?.fillin()
     }
-
-    showStdMsgModal.value = true
-    stdmodal.value?.show()
-    await nextTick()
-    stdmodal.value?.fillin()
+  } catch (e) {
+    console.error('ModMemberButton action failed:', e)
+  } finally {
+    if (callback) callback()
   }
-  if (callback) callback()
   emit('pressed')
 }
 </script>

--- a/modtools/components/ModMemberButtons.vue
+++ b/modtools/components/ModMemberButtons.vue
@@ -245,7 +245,13 @@ function hasCollection(coll) {
 
 const approved = computed(() => hasCollection('Approved'))
 
-const spam = computed(() => member.value.spammer)
+const spam = computed(() => {
+  const s = member.value.spammer
+  // The spammer store writes an enriched object {id, collection, ...} but the
+  // user store can overwrite it with a boolean (true).  Only return the object
+  // form so that template accesses like spam.id / spam.collection work.
+  return s && typeof s === 'object' ? s : null
+})
 
 const validActions = computed(() => {
   // The standard messages we show depend on the valid ones for this type of member.

--- a/modtools/components/ModMemberButtons.vue
+++ b/modtools/components/ModMemberButtons.vue
@@ -78,7 +78,7 @@
         />
       </div>
       <div
-        v-else-if="member.spammer.collection === 'Approved'"
+        v-else-if="member.spammer.collection === 'Spammer'"
         class="d-flex flex-wrap"
       >
         <ModMemberButton

--- a/tests/e2e/test-modtools-spammers.spec.js
+++ b/tests/e2e/test-modtools-spammers.spec.js
@@ -245,4 +245,78 @@ test.describe('ModTools Spammer List', () => {
     expect(badResponses).toHaveLength(0)
     expect(pageErrors).toHaveLength(0)
   })
+
+  test('Reject button sends DELETE with valid id (no 400)', async ({
+    page,
+    testEnv,
+  }) => {
+    // This test covers the bug where member.spammer?.id was undefined
+    // because the enriched spammer object was overwritten by a boolean,
+    // causing DELETE to send {id: null} and get a 400 "Missing id".
+
+    await loginViaModTools(page, testEnv.mod.email)
+
+    // Reset test spammers to PendingAdd with no hold so Reject button is visible.
+    const jwt = await page.evaluate(() => {
+      const auth = JSON.parse(localStorage.getItem('auth') || '{}')
+      return auth?.auth?.jwt
+    })
+    if (jwt && testEnv.spammers) {
+      for (const sid of testEnv.spammers) {
+        await page.request
+          .patch('http://apiv2.localhost/api/modtools/spammers', {
+            data: { id: sid, collection: 'PendingAdd', heldby: null },
+            headers: { Authorization: jwt },
+          })
+          .catch(() => {})
+      }
+    }
+
+    const pageErrors = []
+    const badResponses = []
+    page.on('pageerror', (err) => pageErrors.push(err.message))
+    page.on('response', (resp) => {
+      if (resp.url().includes('/spammers') && resp.status() >= 400) {
+        badResponses.push({ url: resp.url(), status: resp.status() })
+      }
+    })
+
+    // Capture DELETE request bodies to verify id is included.
+    const deleteBodies = []
+    page.on('request', (req) => {
+      if (req.method() === 'DELETE' && req.url().includes('/spammers')) {
+        try {
+          deleteBodies.push(JSON.parse(req.postData() || '{}'))
+        } catch {
+          deleteBodies.push({})
+        }
+      }
+    })
+
+    await goToSpammersPage(page)
+
+    // Click the Reject button on a PendingAdd entry.
+    const rejectBtn = page
+      .locator('.member-card button:has-text("Reject add to spammer list")')
+      .first()
+    await expect(rejectBtn).toBeVisible({ timeout: timeouts.ui.appearance })
+    await rejectBtn.click()
+
+    // Wait for the DELETE request to be sent.
+    await expect
+      .poll(() => deleteBodies.length, {
+        message: 'Waiting for DELETE /spammers request',
+        timeout: timeouts.api.slowApi,
+      })
+      .toBeGreaterThan(0)
+
+    // Verify the request body contains a valid spam_users.id.
+    const body = deleteBodies[0]
+    expect(body.id).toBeTruthy()
+    expect(testEnv.spammers).toContain(body.id)
+
+    // No 400 or other error responses.
+    expect(badResponses).toHaveLength(0)
+    expect(pageErrors).toHaveLength(0)
+  })
 })

--- a/tests/unit/components/modtools/ModMemberButtons.spec.js
+++ b/tests/unit/components/modtools/ModMemberButtons.spec.js
@@ -186,6 +186,20 @@ describe('ModMemberButtons', () => {
       expect(wrapper.text()).toContain('Confirm add to spammer list')
     })
 
+    it('does not render spam buttons when spammer is boolean true (store data race)', () => {
+      // The user store can overwrite the enriched spammer object with a
+      // boolean.  The spam computed must guard against this so template
+      // accesses like spam.id don't fail.
+      const wrapper = mountComponent({
+        member: createMember({
+          spammer: true,
+        }),
+      })
+      expect(wrapper.text()).not.toContain('Confirm add to spammer list')
+      expect(wrapper.text()).not.toContain('Remove from spammer list')
+      expect(wrapper.text()).not.toContain('Hold')
+    })
+
     it('shows spamignore button when spamignore prop is true', () => {
       const wrapper = mountComponent({
         member: createMember({

--- a/tests/unit/components/modtools/ModMemberButtons.spec.js
+++ b/tests/unit/components/modtools/ModMemberButtons.spec.js
@@ -237,10 +237,10 @@ describe('ModMemberButtons', () => {
       expect(wrapper.text()).not.toContain('Hold')
     })
 
-    it('shows remove button for Approved spammers', () => {
+    it('shows remove button for confirmed spammers', () => {
       const wrapper = mountComponent({
         member: createMember({
-          spammer: { id: 222, collection: 'Approved' },
+          spammer: { id: 222, collection: 'Spammer' },
         }),
       })
       expect(wrapper.text()).toContain('Remove from spammer list')


### PR DESCRIPTION
## Summary
- Fixed spam rejection error reported by @Saira — rejecting from spam list caused an unhandled error with a stuck spinner
- Two fixes:
  1. `ModMemberButtons.vue`: Changed `collection === 'Approved'` to `'Spammer'` — spammer records never have 'Approved' collection, so the "Request removal" button was never shown for confirmed spammers
  2. `ModMemberButton.vue`: Added try-catch-finally to `spamRemove()`, `spamRequestRemove()`, and the `click()` handler so the spinner always stops and errors are logged

## Test plan
- [ ] Verify spam list reject button works without error
- [ ] Verify "Request removal from spammer list" button shows for confirmed spammers
- [ ] Verify spinner stops even when API returns an error
- [ ] Run eslint — passes

Reported by @Saira in Discourse #9518 post 123.

🤖 Generated with [Claude Code](https://claude.com/claude-code)