### PR TITLE
fix(ModMessageDuplicate): use route params for duplicate links

### DIFF
--- a/modtools/components/ModMessageDuplicate.vue
+++ b/modtools/components/ModMessageDuplicate.vue
@@ -70,13 +70,6 @@ const isPending = computed(() => {
 
 const duplicateLink = computed(() => {
   const page = isPending.value ? 'pending' : 'approved'
-  return (
-    '/messages/' +
-    page +
-    '?groupid=' +
-    groupid.value +
-    '&msgid=' +
-    message.value.id
-  )
+  return '/messages/' + page + '/' + groupid.value + '/' + message.value.id
 })
 </script>

--- a/tests/unit/components/modtools/ModMessageDuplicate.spec.js
+++ b/tests/unit/components/modtools/ModMessageDuplicate.spec.js
@@ -195,9 +195,7 @@ describe('ModMessageDuplicate', () => {
             groups: [{ groupid: 456 }],
           }
         )
-        expect(wrapper.vm.duplicateLink).toBe(
-          '/messages/pending?groupid=456&msgid=123'
-        )
+        expect(wrapper.vm.duplicateLink).toBe('/messages/pending/456/123')
       })
 
       it('returns approved messages link for approved message', () => {
@@ -208,9 +206,7 @@ describe('ModMessageDuplicate', () => {
             groups: [{ groupid: 456 }],
           }
         )
-        expect(wrapper.vm.duplicateLink).toBe(
-          '/messages/approved?groupid=456&msgid=123'
-        )
+        expect(wrapper.vm.duplicateLink).toBe('/messages/approved/456/123')
       })
 
       it('builds correct link with different groupid and msgid', () => {
@@ -222,9 +218,7 @@ describe('ModMessageDuplicate', () => {
             groups: [{ groupid: 111 }],
           }
         )
-        expect(wrapper.vm.duplicateLink).toBe(
-          '/messages/pending?groupid=111&msgid=999'
-        )
+        expect(wrapper.vm.duplicateLink).toBe('/messages/pending/111/999')
       })
     })
   })
@@ -239,9 +233,7 @@ describe('ModMessageDuplicate', () => {
         }
       )
       const link = wrapper.find('a')
-      expect(link.attributes('href')).toBe(
-        '/messages/pending?groupid=456&msgid=123'
-      )
+      expect(link.attributes('href')).toBe('/messages/pending/456/123')
     })
 
     it('links to correct approved URL', () => {
@@ -253,9 +245,7 @@ describe('ModMessageDuplicate', () => {
         }
       )
       const link = wrapper.find('a')
-      expect(link.attributes('href')).toBe(
-        '/messages/approved?groupid=456&msgid=123'
-      )
+      expect(link.attributes('href')).toBe('/messages/approved/456/123')
     })
   })
 


### PR DESCRIPTION
## Summary
- Duplicate message links now use route params (`/messages/approved/456/123`) instead of query params (`/messages/approved?groupid=456&msgid=123`)
- Query params broke on client-side same-route navigation because `onMounted` only fires once — the page showed all messages for the group instead of navigating to the specific message

## Test plan
- [x] Updated 5 expectations in ModMessageDuplicate.spec.js for route-param format
- [x] Full Vitest suite: 11021/11021 pass

Fixes: Discourse 9481.450-451