### PR TITLE
fix: dashboard topics race condition from separate watchers

### DIFF
--- a/modtools/composables/useModDashboard.js
+++ b/modtools/composables/useModDashboard.js
@@ -57,17 +57,7 @@ export function useModDashboard(props, askfor, grouprequired = false) {
   }
 
   watch(
-    () => props.groupid,
-    () => maybeFetch()
-  )
-
-  watch(
-    () => props.start,
-    () => maybeFetch()
-  )
-
-  watch(
-    () => props.end,
+    () => [props.groupid, props.start, props.end],
     () => maybeFetch()
   )
 

--- a/tests/unit/composables/useModDashboard.spec.js
+++ b/tests/unit/composables/useModDashboard.spec.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
-import { defineComponent, nextTick } from 'vue'
+import { defineComponent, nextTick, reactive } from 'vue'
 
 const mockFetch = vi.fn()
 
@@ -118,5 +118,20 @@ describe('useModDashboard', () => {
     mountWithComposable(props, ['TestComp'], true)
     await flushPromises()
     expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('fires only one fetch when start and end change together', async () => {
+    const props = reactive(createProps())
+    mountWithComposable(props)
+    await flushPromises()
+    mockFetch.mockClear()
+
+    // Simulate the Update button: both start and end change in the same tick.
+    props.start = new Date('2026-02-01')
+    props.end = new Date('2026-02-28')
+    await flushPromises()
+
+    // Combined watcher should batch both changes into a single fetch.
+    expect(mockFetch).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
## Summary
- Dashboard Discourse topics randomly appear/disappear when clicking Update (reported by @Neville_Reid in 9518.161)
- Root cause: three separate watchers on `groupid`, `start`, `end` fire independently when Update changes start+end in the same tick, causing duplicate fetches
- Fix: combine into a single watcher on `[groupid, start, end]` so Vue batches simultaneous changes

## Test plan
- [x] `fires only one fetch when start and end change together` — new test verifies single fetch
- [x] All existing useModDashboard tests pass
- [x] Full Vitest suite: 11018 passed (5 pre-existing failures in ModMessageDuplicate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)