### PR TITLE
fix: sync pagination context + infinite scroll diagnostics

### DIFF
--- a/modtools/composables/useModDashboard.js
+++ b/modtools/composables/useModDashboard.js
@@ -57,17 +57,7 @@ export function useModDashboard(props, askfor, grouprequired = false) {
   }
 
   watch(
-    () => props.groupid,
-    () => maybeFetch()
-  )
-
-  watch(
-    () => props.start,
-    () => maybeFetch()
-  )
-
-  watch(
-    () => props.end,
+    () => [props.groupid, props.start, props.end],
     () => maybeFetch()
   )
 

--- a/modtools/composables/useModMessages.js
+++ b/modtools/composables/useModMessages.js
@@ -149,6 +149,9 @@ export function setupModMessages(reset) {
       fetchedIds.forEach((id) => listingIds.value.add(id))
     }
 
+    // Sync pagination context so loadMore() continues from where getMessages() left off.
+    context.value = messageStore.context
+
     // Force them to show.
     let msgs
 

--- a/modtools/pages/messages/approved/[[id]]/[[term]].vue
+++ b/modtools/pages/messages/approved/[[id]]/[[term]].vue
@@ -221,7 +221,7 @@ async function loadMore($state) {
     show.value++
     $state.loaded()
   } else {
-    const currentCount = Object.keys(messageStore.list).length // Use total messages found, not just messages as this stops too soon
+    const currentCount = Object.keys(messageStore.list).length
 
     let params
 
@@ -261,7 +261,20 @@ async function loadMore($state) {
     }
     context.value = messageStore.context
 
-    if (currentCount === Object.keys(messageStore.list).length) {
+    const newCount = Object.keys(messageStore.list).length
+    if (currentCount === newCount) {
+      console.log('InfiniteScroll complete:', {
+        collection: collection.value,
+        groupid: groupid.value,
+        currentCount,
+        newCount,
+        fetchedIds: fetchedIds?.length ?? 0,
+        contextBefore: params.context,
+        contextAfter: messageStore.context,
+        limit: params.limit,
+        shown: show.value,
+        messagesLen: messages.value.length,
+      })
       $state.complete()
     } else {
       $state.loaded()

--- a/modtools/pages/messages/pending.vue
+++ b/modtools/pages/messages/pending.vue
@@ -266,7 +266,20 @@ async function loadMore($state) {
     }
     context.value = messageStore.context
 
-    if (currentCount === Object.keys(messageStore.list).length) {
+    const newCount = Object.keys(messageStore.list).length
+    if (currentCount === newCount) {
+      console.log('InfiniteScroll complete:', {
+        collection: collection.value,
+        groupid: groupid.value,
+        currentCount,
+        newCount,
+        fetchedIds: fetchedIds?.length ?? 0,
+        contextBefore: params.context,
+        contextAfter: messageStore.context,
+        limit: params.limit,
+        shown: show.value,
+        messagesLen: messages.value.length,
+      })
       $state.complete()
     } else {
       $state.loaded()

--- a/tests/unit/composables/useModDashboard.spec.js
+++ b/tests/unit/composables/useModDashboard.spec.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
-import { defineComponent, nextTick } from 'vue'
+import { defineComponent, nextTick, reactive } from 'vue'
 
 const mockFetch = vi.fn()
 
@@ -118,5 +118,20 @@ describe('useModDashboard', () => {
     mountWithComposable(props, ['TestComp'], true)
     await flushPromises()
     expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('fires only one fetch when start and end change together', async () => {
+    const props = reactive(createProps())
+    mountWithComposable(props)
+    await flushPromises()
+    mockFetch.mockClear()
+
+    // Simulate the Update button: both start and end change in the same tick.
+    props.start = new Date('2026-02-01')
+    props.end = new Date('2026-02-28')
+    await flushPromises()
+
+    // Combined watcher should batch both changes into a single fetch.
+    expect(mockFetch).toHaveBeenCalledTimes(1)
   })
 })

--- a/tests/unit/composables/useModMessages.spec.js
+++ b/tests/unit/composables/useModMessages.spec.js
@@ -15,6 +15,7 @@ const mockClear = vi.fn()
 const mockFetchMessagesMT = vi.fn()
 const mockAll = ref([])
 const mockGetByGroup = vi.fn(() => [])
+const mockStoreContext = ref(null)
 
 vi.mock('~/stores/message', () => ({
   useMessageStore: () => ({
@@ -25,6 +26,13 @@ vi.mock('~/stores/message', () => ({
       return mockAll.value
     },
     getByGroup: mockGetByGroup,
+    get context() {
+      return mockStoreContext.value
+    },
+    set context(v) {
+      mockStoreContext.value = v
+    },
+    list: {},
   }),
 }))
 
@@ -76,6 +84,25 @@ describe('useModMessages getMessages', () => {
     collection.value = 'Pending'
 
     await expect(getMessages()).resolves.toBeUndefined()
+  })
+
+  it('syncs pagination context after getMessages so loadMore continues', async () => {
+    const paginationCtx = { Date: 1700000000, ID: 42 }
+    mockFetchMessagesMT.mockImplementation(() => {
+      mockStoreContext.value = paginationCtx
+      return Promise.resolve([1, 2, 3])
+    })
+    mockAll.value = [{ id: 1 }, { id: 2 }, { id: 3 }]
+
+    const { setupModMessages } = await import(
+      '~/modtools/composables/useModMessages'
+    )
+    const { getMessages, collection, context } = setupModMessages()
+    collection.value = 'Approved'
+    await getMessages()
+
+    // context ref should be synced from the store so loadMore() can paginate.
+    expect(context.value).toEqual(paginationCtx)
   })
 
   it('resets show count to 0 on 401 so UI does not show stale message count', async () => {


### PR DESCRIPTION
## Summary
- **Context sync bug**: `getMessages()` in useModMessages didn't sync `context.value` from the store after fetching, so `loadMore()` always started pagination from scratch (context=null) instead of continuing from where getMessages left off
- **Diagnostics**: Added `console.log` when infinite scroll reaches `complete()` in approved.vue and pending.vue — logs context, counts, fetchedIds, and limit to help diagnose Neville's intermittent scroll stoppage (9518.160)

## Test plan
- [x] `syncs pagination context after getMessages so loadMore continues` — new test
- [x] All existing useModMessages tests pass
- [x] Full Vitest suite: 11018 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)