### PR TITLE
fix: don't show mod's own profile in User2Mod chat header

### DIFF
--- a/modtools/components/ModChatHeader.vue
+++ b/modtools/components/ModChatHeader.vue
@@ -470,13 +470,17 @@ const showblock = () => {
 }
 
 const showInfo = () => {
-  // MT: Navigate to member page instead of showing profile modal
-  navigateTo(
-    '/members/approved/' +
-      (chat.value.groupid || chat.value.group?.id) +
-      '/' +
-      (chat.value.otheruid || chat.value.user1)
-  )
+  // MT: Navigate to member page instead of showing profile modal.
+  // Only navigate if there's a real other user (not for User2Mod where mod is user1).
+  const uid = chat.value.otheruid
+  if (uid) {
+    navigateTo(
+      '/members/approved/' +
+        (chat.value.groupid || chat.value.group?.id) +
+        '/' +
+        uid
+    )
+  }
 }
 
 const report = () => {

--- a/modtools/composables/useChatMT.js
+++ b/modtools/composables/useChatMT.js
@@ -21,20 +21,15 @@ function useChatSharedMT(chatId) {
     return chatId ? chatStore.byChatId(chatId) : null
   })
 
-  // MT: Handle otheruser for User2Mod chats where otheruid may not be set
+  // MT: Handle otheruser — the member on the other side of the chat.
+  // For User2Mod chats where the mod IS user1 (they contacted the group),
+  // otheruid is cleared to 0 by the API and user1 is the mod themselves —
+  // don't fall back to showing the mod's own profile.
   const otheruser = computed(() => {
-    let otheruid = chat.value?.otheruid
-    let user = null
+    const otheruid = chat.value?.otheruid
+    if (!otheruid) return null
 
-    if (!otheruid) {
-      otheruid = chat.value?.user1
-    }
-
-    if (otheruid) {
-      user = userStore.byId(otheruid)
-    }
-
-    return user
+    return userStore.byId(otheruid)
   })
 
   return {

--- a/tests/unit/components/modtools/ModChatHeader.spec.js
+++ b/tests/unit/components/modtools/ModChatHeader.spec.js
@@ -423,7 +423,7 @@ describe('ModChatHeader', () => {
       expect(mockNavigateTo).toHaveBeenCalledWith('/members/approved/789/456')
     })
 
-    it('showInfo uses otheruid over user1', async () => {
+    it('showInfo uses otheruid only, not user1 fallback', async () => {
       mockChat.value = createChat({
         groupid: 111,
         otheruid: 500,
@@ -433,6 +433,20 @@ describe('ModChatHeader', () => {
       const inner = getInner(wrapper)
       inner.vm.showInfo()
       expect(mockNavigateTo).toHaveBeenCalledWith('/members/approved/111/500')
+    })
+
+    it('showInfo does not navigate when otheruid is 0 (User2Mod where mod is user1)', async () => {
+      mockChat.value = createChat({
+        chattype: 'User2Mod',
+        groupid: 111,
+        otheruid: 0,
+        user1: 456,
+      })
+      mockOtheruser.value = null
+      const wrapper = await mountComponent()
+      const inner = getInner(wrapper)
+      inner.vm.showInfo()
+      expect(mockNavigateTo).not.toHaveBeenCalled()
     })
 
     it('markRead calls chatStore.markRead and fetchChat', async () => {


### PR DESCRIPTION
## Summary
- When a mod views a User2Mod chat where they are user1 (they contacted the group), the chat header showed the mod's own profile sentence, "About X miles away", and membership notes (reported by @Neville_Reid in 9481.456/458)
- Root cause: API clears `otheruid` to 0 when the mod IS user1, frontend fell back to `user1` which is the mod's own ID
- Fix: remove the `user1` fallback — if `otheruid` is 0, return null so no profile info is shown

## Test plan
- [x] `showInfo does not navigate when otheruid is 0 (User2Mod where mod is user1)` — new test
- [x] All 32 ModChatHeader tests pass
- [x] Full Vitest suite: no new failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)