### PR TITLE
fix: SysAdmin menu badge admin-only

### DIFF
--- a/modtools/layouts/default.vue
+++ b/modtools/layouts/default.vue
@@ -225,9 +225,7 @@
           link="/sysadmin"
           name="SysAdmin"
           :count="
-            supportOrAdmin
-              ? ['housekeeping', 'cronjobs', 'emailin', 'emailout']
-              : []
+            admin ? ['housekeeping', 'cronjobs', 'emailin', 'emailout'] : []
           "
           @mobilehidemenu="mobilehidemenu"
         />
@@ -304,7 +302,7 @@ const miscStore = useMiscStore()
 const modGroupStore = useModGroupStore()
 const modConfigStore = useModConfigStore()
 const persistent = authStore.auth.persistent
-const { supportOrAdmin } = useMe()
+const { supportOrAdmin, admin } = useMe()
 const {
   hasPermissionNewsletter,
   hasPermissionSpamAdmin,

--- a/tests/unit/components/modtools/ModMenuItemLeft.spec.js
+++ b/tests/unit/components/modtools/ModMenuItemLeft.spec.js
@@ -170,6 +170,31 @@ describe('ModMenuItemLeft', () => {
       expect(wrapper.find('.badge-danger').exists()).toBe(false)
     })
 
+    it('does not show badge when count is empty array (non-admin sysadmin)', () => {
+      // When a non-admin views SysAdmin, count is [] — no badge should show
+      // even if work contains sysadmin-related counts.
+      mockAuthStore.work = { housekeeping: 2, cronjobs: 1, emailin: 1 }
+      const wrapper = mountModMenuItemLeft({
+        count: [],
+      })
+      expect(wrapper.find('.badge-danger').exists()).toBe(false)
+    })
+
+    it('shows badge for sysadmin count types when admin', () => {
+      // Admin users get count=['housekeeping','cronjobs','emailin','emailout']
+      mockAuthStore.work = {
+        housekeeping: 2,
+        cronjobs: 1,
+        emailin: 0,
+        emailout: 0,
+      }
+      const wrapper = mountModMenuItemLeft({
+        count: ['housekeeping', 'cronjobs', 'emailin', 'emailout'],
+      })
+      expect(wrapper.find('.badge-danger').exists()).toBe(true)
+      expect(wrapper.text()).toContain('3')
+    })
+
     it('applies correct variant to count badge', () => {
       const wrapper = mountModMenuItemLeft({
         count: ['pending'],


### PR DESCRIPTION
## Summary
- SysAdmin menu badge (housekeeping, cronjobs, emailin, emailout work counts) was showing for Support users
- Changed the count condition from `supportOrAdmin` to `admin` so only admin users see the red badge
- The SysAdmin tab itself remains visible to both support and admin users

## Test plan
- [x] Added 2 new tests to ModMenuItemLeft.spec.js verifying empty array = no badge, populated array = badge
- [x] All 19 ModMenuItemLeft tests pass
- [ ] Manual verification: login as Support user, confirm no red badge on SysAdmin menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)