### PR TITLE
test(stores): notification, tryst, reply store tests (29)

### DIFF
--- a/tests/unit/stores/notification.spec.js
+++ b/tests/unit/stores/notification.spec.js
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+const mockCount = vi.fn()
+const mockList = vi.fn()
+const mockSeen = vi.fn()
+const mockAllSeen = vi.fn()
+
+vi.mock('~/api', () => ({
+  default: () => ({
+    notification: {
+      count: mockCount,
+      list: mockList,
+      seen: mockSeen,
+      allSeen: mockAllSeen,
+    },
+  }),
+}))
+
+// Re-export APIError for instanceof checks
+class MockAPIError extends Error {
+  constructor(message, response) {
+    super(message)
+    this.name = 'APIError'
+    this.response = response
+  }
+}
+
+vi.mock('~/api/APIErrors', () => ({
+  APIError: MockAPIError,
+}))
+
+describe('notification store', () => {
+  let useNotificationStore
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    setActivePinia(createPinia())
+    const mod = await import('~/stores/notification')
+    useNotificationStore = mod.useNotificationStore
+  })
+
+  describe('initial state', () => {
+    it('starts with empty list and zero count', () => {
+      const store = useNotificationStore()
+      expect(store.list).toEqual([])
+      expect(store.listById).toEqual({})
+      expect(store.count).toBe(0)
+    })
+  })
+
+  describe('fetchCount', () => {
+    it('fetches and stores count', async () => {
+      const store = useNotificationStore()
+      store.init({ public: {} })
+      mockCount.mockResolvedValue({ count: 5 })
+
+      const result = await store.fetchCount()
+      expect(result).toBe(5)
+      expect(store.count).toBe(5)
+    })
+
+    it('swallows 401 errors', async () => {
+      const store = useNotificationStore()
+      store.init({ public: {} })
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+      mockCount.mockRejectedValue(
+        new MockAPIError('Unauthorized', { status: 401 })
+      )
+
+      // Should not throw
+      await store.fetchCount()
+      logSpy.mockRestore()
+    })
+
+    it('rethrows non-401 API errors', async () => {
+      const store = useNotificationStore()
+      store.init({ public: {} })
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+      mockCount.mockRejectedValue(
+        new MockAPIError('Server error', { status: 500 })
+      )
+
+      await expect(store.fetchCount()).rejects.toThrow('Server error')
+      logSpy.mockRestore()
+    })
+
+    it('swallows non-APIError exceptions', async () => {
+      const store = useNotificationStore()
+      store.init({ public: {} })
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+      mockCount.mockRejectedValue(new Error('Network error'))
+
+      // Should not throw (not an APIError)
+      await store.fetchCount()
+      logSpy.mockRestore()
+    })
+  })
+
+  describe('fetchList', () => {
+    it('fetches list and populates listById', async () => {
+      const store = useNotificationStore()
+      store.init({ public: {} })
+      mockList.mockResolvedValue([
+        { id: 1, title: 'Notif 1' },
+        { id: 2, title: 'Notif 2' },
+      ])
+
+      const result = await store.fetchList()
+      expect(result).toHaveLength(2)
+      expect(store.listById[1].title).toBe('Notif 1')
+      expect(store.listById[2].title).toBe('Notif 2')
+    })
+
+    it('does not overwrite existing listById entries', async () => {
+      const store = useNotificationStore()
+      store.init({ public: {} })
+      store.listById[1] = { id: 1, title: 'Original' }
+      mockList.mockResolvedValue([{ id: 1, title: 'Updated' }])
+
+      await store.fetchList()
+      expect(store.listById[1].title).toBe('Original')
+    })
+
+    it('swallows 401 errors', async () => {
+      const store = useNotificationStore()
+      store.init({ public: {} })
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+      mockList.mockRejectedValue(
+        new MockAPIError('Unauthorized', { status: 401 })
+      )
+
+      await store.fetchList()
+      logSpy.mockRestore()
+    })
+  })
+
+  describe('seen', () => {
+    it('marks notification seen and refetches count', async () => {
+      const store = useNotificationStore()
+      store.init({ public: {} })
+      mockSeen.mockResolvedValue({})
+      mockCount.mockResolvedValue({ count: 3 })
+
+      await store.seen(42)
+      expect(mockSeen).toHaveBeenCalledWith(42)
+      expect(mockCount).toHaveBeenCalled()
+    })
+  })
+
+  describe('allSeen', () => {
+    it('marks all seen and refetches count', async () => {
+      const store = useNotificationStore()
+      store.init({ public: {} })
+      mockAllSeen.mockResolvedValue({})
+      mockCount.mockResolvedValue({ count: 0 })
+
+      await store.allSeen(42)
+      expect(mockAllSeen).toHaveBeenCalledWith(42)
+      expect(store.count).toBe(0)
+    })
+  })
+
+  describe('byId getter', () => {
+    it('returns notification by id', () => {
+      const store = useNotificationStore()
+      store.listById[42] = { id: 42, title: 'Test' }
+      expect(store.byId(42)).toEqual({ id: 42, title: 'Test' })
+    })
+
+    it('returns undefined for unknown id', () => {
+      const store = useNotificationStore()
+      expect(store.byId(999)).toBeUndefined()
+    })
+  })
+})

--- a/tests/unit/stores/reply.spec.js
+++ b/tests/unit/stores/reply.spec.js
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+describe('reply store', () => {
+  let useReplyStore
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    setActivePinia(createPinia())
+    const mod = await import('~/stores/reply')
+    useReplyStore = mod.useReplyStore
+  })
+
+  describe('initial state', () => {
+    it('starts with null/false defaults', () => {
+      const store = useReplyStore()
+      expect(store.replyMsgId).toBeNull()
+      expect(store.replyMessage).toBeNull()
+      expect(store.replyingAt).toBeNull()
+      expect(store.machineState).toBeNull()
+      expect(store.isNewUser).toBe(false)
+    })
+  })
+
+  describe('clearReply', () => {
+    it('resets all reply state', () => {
+      const store = useReplyStore()
+      store.replyMsgId = 42
+      store.replyMessage = 'Hello'
+      store.replyingAt = Date.now()
+      store.machineState = 'composing'
+      store.isNewUser = true
+
+      store.clearReply()
+
+      expect(store.replyMsgId).toBeNull()
+      expect(store.replyMessage).toBeNull()
+      expect(store.replyingAt).toBeNull()
+      expect(store.machineState).toBeNull()
+      expect(store.isNewUser).toBe(false)
+    })
+  })
+
+  describe('saveMachineState', () => {
+    it('saves state and isNewUser', () => {
+      const store = useReplyStore()
+      store.saveMachineState('waitingForEmail', true)
+      expect(store.machineState).toBe('waitingForEmail')
+      expect(store.isNewUser).toBe(true)
+    })
+
+    it('defaults isNewUser to false', () => {
+      const store = useReplyStore()
+      store.saveMachineState('composing')
+      expect(store.machineState).toBe('composing')
+      expect(store.isNewUser).toBe(false)
+    })
+  })
+})

--- a/tests/unit/stores/tryst.spec.js
+++ b/tests/unit/stores/tryst.spec.js
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+const mockFetch = vi.fn()
+const mockAdd = vi.fn()
+const mockEdit = vi.fn()
+const mockDel = vi.fn()
+
+vi.mock('~/api', () => ({
+  default: () => ({
+    tryst: {
+      fetch: mockFetch,
+      add: mockAdd,
+      edit: mockEdit,
+      delete: mockDel,
+    },
+  }),
+}))
+
+describe('tryst store', () => {
+  let useTrystStore
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    setActivePinia(createPinia())
+    const mod = await import('~/stores/tryst')
+    useTrystStore = mod.useTrystStore
+  })
+
+  describe('initial state', () => {
+    it('starts with empty list', () => {
+      const store = useTrystStore()
+      expect(store.list).toEqual([])
+      expect(store.fetching).toBeNull()
+    })
+  })
+
+  describe('fetch', () => {
+    it('fetches and stores trysts', async () => {
+      const store = useTrystStore()
+      store.init({ public: {} })
+      mockFetch.mockResolvedValue({
+        trysts: [{ id: 1, user1: 10, user2: 20 }],
+      })
+
+      await store.fetch()
+      expect(store.list).toHaveLength(1)
+      expect(store.list[0].id).toBe(1)
+    })
+
+    it('deduplicates concurrent fetches', async () => {
+      const store = useTrystStore()
+      store.init({ public: {} })
+
+      let resolveFirst
+      const firstPromise = new Promise((r) => {
+        resolveFirst = r
+      })
+      mockFetch.mockReturnValueOnce(firstPromise)
+
+      const fetch1 = store.fetch()
+      const fetch2 = store.fetch()
+
+      resolveFirst({ trysts: [{ id: 1 }] })
+      await fetch1
+      await fetch2
+
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('add', () => {
+    it('adds tryst and refetches', async () => {
+      const store = useTrystStore()
+      store.init({ public: {} })
+      mockAdd.mockResolvedValue(99)
+      mockFetch.mockResolvedValue({ trysts: [{ id: 99 }] })
+
+      const id = await store.add(10, 20, '2026-05-01')
+      expect(id).toBe(99)
+      expect(mockAdd).toHaveBeenCalledWith({
+        user1: 10,
+        user2: 20,
+        arrangedfor: '2026-05-01',
+      })
+      expect(mockFetch).toHaveBeenCalled()
+    })
+
+    it('does not refetch when add returns falsy', async () => {
+      const store = useTrystStore()
+      store.init({ public: {} })
+      mockAdd.mockResolvedValue(null)
+
+      await store.add(10, 20, '2026-05-01')
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('edit', () => {
+    it('edits tryst and refetches', async () => {
+      const store = useTrystStore()
+      store.init({ public: {} })
+      mockEdit.mockResolvedValue({})
+      mockFetch.mockResolvedValue({ trysts: [] })
+
+      await store.edit(1, '2026-06-01')
+      expect(mockEdit).toHaveBeenCalledWith({
+        id: 1,
+        arrangedfor: '2026-06-01',
+      })
+      expect(mockFetch).toHaveBeenCalled()
+    })
+  })
+
+  describe('delete', () => {
+    it('deletes tryst and refetches', async () => {
+      const store = useTrystStore()
+      store.init({ public: {} })
+      mockDel.mockResolvedValue({})
+      mockFetch.mockResolvedValue({ trysts: [] })
+
+      await store.delete(1)
+      expect(mockDel).toHaveBeenCalledWith({ id: 1 })
+      expect(mockFetch).toHaveBeenCalled()
+    })
+  })
+
+  describe('get getter', () => {
+    it('finds tryst by id', () => {
+      const store = useTrystStore()
+      store.list = [
+        { id: 1, user1: 10, user2: 20 },
+        { id: 2, user1: 30, user2: 40 },
+      ]
+      expect(store.get(2)).toEqual({ id: 2, user1: 30, user2: 40 })
+    })
+
+    it('returns undefined for unknown id', () => {
+      const store = useTrystStore()
+      store.list = [{ id: 1 }]
+      expect(store.get(999)).toBeUndefined()
+    })
+  })
+
+  describe('getByUser getter', () => {
+    it('finds tryst where user is user1', () => {
+      const store = useTrystStore()
+      store.list = [{ id: 1, user1: 10, user2: 20 }]
+      expect(store.getByUser(10)).toEqual({ id: 1, user1: 10, user2: 20 })
+    })
+
+    it('finds tryst where user is user2', () => {
+      const store = useTrystStore()
+      store.list = [{ id: 1, user1: 10, user2: 20 }]
+      expect(store.getByUser(20)).toEqual({ id: 1, user1: 10, user2: 20 })
+    })
+
+    it('matches with string/number coercion', () => {
+      const store = useTrystStore()
+      store.list = [{ id: 1, user1: '10', user2: '20' }]
+      expect(store.getByUser(10)).toBeDefined()
+    })
+
+    it('returns undefined when no match', () => {
+      const store = useTrystStore()
+      store.list = [{ id: 1, user1: 10, user2: 20 }]
+      expect(store.getByUser(99)).toBeUndefined()
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Adds unit tests for 3 previously untested stores:
  - **notification.js** (74 lines): 12 tests — fetchCount/fetchList with 401 error swallowing, seen/allSeen with count refresh, listById immutability on re-fetch, byId getter
  - **tryst.js** (71 lines): 13 tests — fetch with concurrent dedup, CRUD (add/edit/delete) with automatic refetch, get/getByUser getters with string/number coercion
  - **reply.js** (61 lines): 4 tests — clearReply state reset, saveMachineState with default isNewUser parameter

## Test plan
- [x] All 29 tests pass locally via status container
- [ ] CI green on FreegleDocker

