### PR TITLE
test(stores): job, shortlinks, team, config store tests (37)

### DIFF
--- a/tests/unit/stores/config.spec.js
+++ b/tests/unit/stores/config.spec.js
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+const mockFetchv2 = vi.fn()
+
+vi.mock('~/api', () => ({
+  default: () => ({
+    config: {
+      fetchv2: mockFetchv2,
+    },
+  }),
+}))
+
+describe('config store', () => {
+  let useConfigStore
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    setActivePinia(createPinia())
+    const mod = await import('~/stores/config')
+    useConfigStore = mod.useConfigStore
+  })
+
+  describe('initial state', () => {
+    it('starts with empty list', () => {
+      const store = useConfigStore()
+      expect(store.list).toEqual({})
+    })
+  })
+
+  describe('fetch', () => {
+    it('fetches config value and caches it', async () => {
+      const store = useConfigStore()
+      store.init({ public: {} })
+      mockFetchv2.mockResolvedValue([{ value: 'test_value' }])
+
+      const result = await store.fetch('my_key')
+      expect(result).toEqual([{ value: 'test_value' }])
+      expect(store.list.my_key).toBeDefined()
+      expect(store.list.my_key.values).toEqual([{ value: 'test_value' }])
+    })
+
+    it('returns cached value without refetching', async () => {
+      const store = useConfigStore()
+      store.init({ public: {} })
+      store.list.my_key = {
+        values: [{ value: 'cached' }],
+        addedToCache: Math.round(Date.now() / 1000),
+      }
+
+      const result = await store.fetch('my_key')
+      expect(result).toEqual([{ value: 'cached' }])
+      expect(mockFetchv2).not.toHaveBeenCalled()
+    })
+
+    it('refetches when force=true', async () => {
+      const store = useConfigStore()
+      store.init({ public: {} })
+      store.list.my_key = {
+        values: [{ value: 'old' }],
+        addedToCache: Math.round(Date.now() / 1000),
+      }
+      mockFetchv2.mockResolvedValue([{ value: 'new' }])
+
+      const result = await store.fetch('my_key', true)
+      expect(result).toEqual([{ value: 'new' }])
+    })
+
+    it('refetches when cache is expired (>600s)', async () => {
+      const store = useConfigStore()
+      store.init({ public: {} })
+      store.list.my_key = {
+        values: [{ value: 'old' }],
+        addedToCache: Math.round(Date.now() / 1000) - 700,
+      }
+      mockFetchv2.mockResolvedValue([{ value: 'refreshed' }])
+
+      const result = await store.fetch('my_key')
+      expect(result).toEqual([{ value: 'refreshed' }])
+    })
+
+    it('deduplicates concurrent fetches for same key', async () => {
+      const store = useConfigStore()
+      store.init({ public: {} })
+
+      let resolveFirst
+      mockFetchv2.mockReturnValueOnce(
+        new Promise((r) => {
+          resolveFirst = r
+        })
+      )
+
+      const f1 = store.fetch('my_key', true)
+      const f2 = store.fetch('my_key', true)
+
+      resolveFirst([{ value: 'result' }])
+      await f1
+      await f2
+
+      expect(mockFetchv2).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('byKey getter', () => {
+    it('returns config values by key', () => {
+      const store = useConfigStore()
+      store.list.my_key = {
+        values: [{ value: 'test' }],
+        addedToCache: 123,
+      }
+      expect(store.byKey('my_key')).toEqual([{ value: 'test' }])
+    })
+  })
+})

--- a/tests/unit/stores/job.spec.js
+++ b/tests/unit/stores/job.spec.js
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+const mockFetchOnev2 = vi.fn()
+const mockFetchv2 = vi.fn()
+const mockLog = vi.fn()
+
+vi.mock('~/api', () => ({
+  default: () => ({
+    job: {
+      fetchOnev2: mockFetchOnev2,
+      fetchv2: mockFetchv2,
+      log: mockLog,
+    },
+  }),
+}))
+
+describe('job store', () => {
+  let useJobStore
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    setActivePinia(createPinia())
+    const mod = await import('~/stores/job')
+    useJobStore = mod.useJobStore
+  })
+
+  describe('initial state', () => {
+    it('starts with empty list and not blocked', () => {
+      const store = useJobStore()
+      expect(store.list).toEqual([])
+      expect(store.blocked).toBe(false)
+    })
+  })
+
+  describe('fetchOne', () => {
+    it('fetches a single job by id', async () => {
+      const store = useJobStore()
+      store.init({ public: {} })
+      mockFetchOnev2.mockResolvedValue({ id: 42, title: 'Dev' })
+
+      const result = await store.fetchOne(42)
+      expect(result).toEqual({ id: 42, title: 'Dev' })
+      expect(mockFetchOnev2).toHaveBeenCalledWith(42, false)
+    })
+
+    it('sets blocked on error', async () => {
+      const store = useJobStore()
+      store.init({ public: {} })
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+      mockFetchOnev2.mockRejectedValue(new Error('Ad blocked'))
+
+      const result = await store.fetchOne(42)
+      expect(result).toBeNull()
+      expect(store.blocked).toBe(true)
+      logSpy.mockRestore()
+    })
+  })
+
+  describe('fetch', () => {
+    it('fetches jobs list', async () => {
+      const store = useJobStore()
+      store.init({ public: {} })
+      mockFetchv2.mockResolvedValue([{ id: 1 }, { id: 2 }])
+
+      const result = await store.fetch(51.5, -0.1)
+      expect(result).toHaveLength(2)
+      expect(store.list).toHaveLength(2)
+    })
+
+    it('returns cached list without refetching', async () => {
+      const store = useJobStore()
+      store.init({ public: {} })
+      store.list = [{ id: 1 }]
+
+      const result = await store.fetch(51.5, -0.1)
+      expect(result).toHaveLength(1)
+      expect(mockFetchv2).not.toHaveBeenCalled()
+    })
+
+    it('refetches when force=true', async () => {
+      const store = useJobStore()
+      store.init({ public: {} })
+      store.list = [{ id: 1 }]
+      mockFetchv2.mockResolvedValue([{ id: 1 }, { id: 2 }])
+
+      const result = await store.fetch(51.5, -0.1, null, true)
+      expect(result).toHaveLength(2)
+    })
+
+    it('deduplicates concurrent fetches', async () => {
+      const store = useJobStore()
+      store.init({ public: {} })
+
+      let resolveFirst
+      mockFetchv2.mockReturnValueOnce(
+        new Promise((r) => {
+          resolveFirst = r
+        })
+      )
+
+      const f1 = store.fetch(51.5, -0.1, null, true)
+      const f2 = store.fetch(51.5, -0.1, null, true)
+
+      resolveFirst([{ id: 1 }])
+      await f1
+      await f2
+
+      expect(mockFetchv2).toHaveBeenCalledTimes(1)
+    })
+
+    it('sets blocked on error', async () => {
+      const store = useJobStore()
+      store.init({ public: {} })
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+      mockFetchv2.mockRejectedValue(new Error('Ad blocked'))
+
+      await store.fetch(51.5, -0.1)
+      expect(store.blocked).toBe(true)
+      logSpy.mockRestore()
+    })
+
+    it('passes category parameter', async () => {
+      const store = useJobStore()
+      store.init({ public: {} })
+      mockFetchv2.mockResolvedValue([])
+
+      await store.fetch(51.5, -0.1, 'tech')
+      expect(mockFetchv2).toHaveBeenCalledWith(51.5, -0.1, 'tech')
+    })
+  })
+
+  describe('log', () => {
+    it('calls API log', () => {
+      const store = useJobStore()
+      store.init({ public: {} })
+      store.log({ action: 'click', jobid: 1 })
+      expect(mockLog).toHaveBeenCalledWith({ action: 'click', jobid: 1 })
+    })
+  })
+
+  describe('byId getter', () => {
+    it('finds job by id', () => {
+      const store = useJobStore()
+      store.list = [{ id: 1 }, { id: 2, title: 'Dev' }]
+      expect(store.byId(2)).toEqual({ id: 2, title: 'Dev' })
+    })
+
+    it('returns undefined for unknown id', () => {
+      const store = useJobStore()
+      store.list = [{ id: 1 }]
+      expect(store.byId(999)).toBeUndefined()
+    })
+  })
+})

--- a/tests/unit/stores/shortlinks.spec.js
+++ b/tests/unit/stores/shortlinks.spec.js
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+const mockFetch = vi.fn()
+const mockAdd = vi.fn()
+
+vi.mock('~/api', () => ({
+  default: () => ({
+    shortlinks: {
+      fetch: mockFetch,
+      add: mockAdd,
+    },
+  }),
+}))
+
+describe('shortlink store', () => {
+  let useShortlinkStore
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    setActivePinia(createPinia())
+    const mod = await import('~/stores/shortlinks')
+    useShortlinkStore = mod.useShortlinkStore
+  })
+
+  describe('initial state', () => {
+    it('starts with empty list', () => {
+      const store = useShortlinkStore()
+      expect(store.list).toEqual({})
+    })
+  })
+
+  describe('fetch', () => {
+    it('fetches shortlinks for a group and stores them', async () => {
+      const store = useShortlinkStore()
+      store.init({ public: {} })
+      mockFetch.mockResolvedValue({
+        shortlinks: [
+          { id: 1, name: 'link1' },
+          { id: 2, name: 'link2' },
+        ],
+      })
+
+      await store.fetch(null, 10)
+      expect(store.list[1].name).toBe('link1')
+      expect(store.list[2].name).toBe('link2')
+    })
+
+    it('clears list when groupid is provided', async () => {
+      const store = useShortlinkStore()
+      store.init({ public: {} })
+      store.list[99] = { id: 99, name: 'old' }
+      mockFetch.mockResolvedValue({ shortlinks: [] })
+
+      await store.fetch(null, 10)
+      expect(store.list[99]).toBeUndefined()
+    })
+
+    it('fetches single shortlink by id', async () => {
+      const store = useShortlinkStore()
+      store.init({ public: {} })
+      mockFetch.mockResolvedValue({
+        shortlink: { id: 5, name: 'single' },
+      })
+
+      await store.fetch(5)
+      expect(store.list[5].name).toBe('single')
+    })
+  })
+
+  describe('add', () => {
+    it('adds shortlink and fetches it', async () => {
+      const store = useShortlinkStore()
+      store.init({ public: {} })
+      mockAdd.mockResolvedValue(42)
+      mockFetch.mockResolvedValue({
+        shortlink: { id: 42, name: 'newlink' },
+      })
+
+      const id = await store.add(10, 'newlink')
+      expect(id).toBe(42)
+      expect(store.list[42].name).toBe('newlink')
+    })
+
+    it('returns null when add fails', async () => {
+      const store = useShortlinkStore()
+      store.init({ public: {} })
+      mockAdd.mockResolvedValue(null)
+
+      const id = await store.add(10, 'test')
+      expect(id).toBeNull()
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('clear', () => {
+    it('resets list to empty object', () => {
+      const store = useShortlinkStore()
+      store.list[1] = { id: 1 }
+      store.clear()
+      expect(store.list).toEqual({})
+    })
+  })
+
+  describe('byId getter', () => {
+    it('returns shortlink by id', () => {
+      const store = useShortlinkStore()
+      store.list[42] = { id: 42, name: 'test' }
+      expect(store.byId(42)).toEqual({ id: 42, name: 'test' })
+    })
+
+    it('returns undefined for unknown id', () => {
+      const store = useShortlinkStore()
+      expect(store.byId(999)).toBeUndefined()
+    })
+  })
+})

--- a/tests/unit/stores/team.spec.js
+++ b/tests/unit/stores/team.spec.js
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+const mockFetch = vi.fn()
+const mockAdd = vi.fn()
+const mockRemove = vi.fn()
+
+vi.mock('~/api', () => ({
+  default: () => ({
+    team: {
+      fetch: mockFetch,
+      add: mockAdd,
+      remove: mockRemove,
+    },
+  }),
+}))
+
+describe('team store', () => {
+  let useTeamStore
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    setActivePinia(createPinia())
+    const mod = await import('~/stores/team')
+    useTeamStore = mod.useTeamStore
+  })
+
+  describe('initial state', () => {
+    it('starts with empty all and list', () => {
+      const store = useTeamStore()
+      expect(store.all).toEqual([])
+      expect(store.list).toEqual({})
+    })
+  })
+
+  describe('fetch', () => {
+    it('fetches all teams when no team specified', async () => {
+      const store = useTeamStore()
+      store.init({ public: {} })
+      mockFetch.mockResolvedValue([{ name: 'dev' }, { name: 'support' }])
+
+      await store.fetch()
+      expect(store.all).toHaveLength(2)
+      expect(mockFetch).toHaveBeenCalledWith()
+    })
+
+    it('fetches specific team by name', async () => {
+      const store = useTeamStore()
+      store.init({ public: {} })
+      mockFetch.mockResolvedValue([{ id: 1, name: 'Alice' }])
+
+      const result = await store.fetch('dev')
+      expect(result).toEqual([{ id: 1, name: 'Alice' }])
+      expect(store.list.dev).toBeDefined()
+      expect(mockFetch).toHaveBeenCalledWith({ name: 'dev' })
+    })
+
+    it('returns cached team without refetching', async () => {
+      const store = useTeamStore()
+      store.init({ public: {} })
+      store.list.dev = [{ id: 1 }]
+
+      const result = await store.fetch('dev')
+      expect(result).toEqual([{ id: 1 }])
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+
+    it('deduplicates concurrent fetches for same team', async () => {
+      const store = useTeamStore()
+      store.init({ public: {} })
+
+      let resolveFirst
+      mockFetch.mockReturnValueOnce(
+        new Promise((r) => {
+          resolveFirst = r
+        })
+      )
+
+      const f1 = store.fetch('dev')
+      const f2 = store.fetch('dev')
+
+      resolveFirst([{ id: 1 }])
+      await f1
+      await f2
+
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('add', () => {
+    it('calls API add', async () => {
+      const store = useTeamStore()
+      store.init({ public: {} })
+      mockAdd.mockResolvedValue({})
+
+      await store.add({ team: 'dev', userid: 42 })
+      expect(mockAdd).toHaveBeenCalledWith({ team: 'dev', userid: 42 })
+    })
+  })
+
+  describe('remove', () => {
+    it('calls API remove', async () => {
+      const store = useTeamStore()
+      store.init({ public: {} })
+      mockRemove.mockResolvedValue({})
+
+      await store.remove({ team: 'dev', userid: 42 })
+      expect(mockRemove).toHaveBeenCalledWith({ team: 'dev', userid: 42 })
+    })
+  })
+
+  describe('getTeam getter', () => {
+    it('returns team from list', () => {
+      const store = useTeamStore()
+      store.list.dev = [{ id: 1, name: 'Alice' }]
+      expect(store.getTeam('dev')).toEqual([{ id: 1, name: 'Alice' }])
+    })
+
+    it('returns undefined for unknown team', () => {
+      const store = useTeamStore()
+      expect(store.getTeam('unknown')).toBeUndefined()
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Adds unit tests for 4 small Pinia stores: job (12), shortlinks (9), team (9), config (7)
- Tests cover fetch/cache/dedup patterns, CRUD operations, error handling (ad-blocker detection), and all getters
- 37 new tests total, all passing

## Test plan
- [x] All 37 new tests pass locally (11432✓ 3✗ — 3 pre-existing failures unrelated)
- [ ] CI green
