### PR TITLE
test(stores): remaining 12 store tests (79)

### DIFF
--- a/tests/unit/stores/authority.spec.js
+++ b/tests/unit/stores/authority.spec.js
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+const mockFetch = vi.fn()
+const mockFetchMessages = vi.fn()
+
+vi.mock('~/api', () => ({
+  default: () => ({
+    authority: {
+      fetch: mockFetch,
+      fetchMessages: mockFetchMessages,
+    },
+  }),
+}))
+
+describe('authority store', () => {
+  let useAuthorityStore
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    setActivePinia(createPinia())
+    const mod = await import('~/stores/authority')
+    useAuthorityStore = mod.useAuthorityStore
+  })
+
+  describe('initial state', () => {
+    it('starts with empty list', () => {
+      const store = useAuthorityStore()
+      expect(store.list).toEqual({})
+    })
+  })
+
+  describe('fetch', () => {
+    it('fetches authority by id and caches it', async () => {
+      const store = useAuthorityStore()
+      store.init({ public: {} })
+      mockFetch.mockResolvedValue({ id: 1, name: 'Council A' })
+
+      const result = await store.fetch(1)
+      expect(result).toEqual({ id: 1, name: 'Council A' })
+      expect(store.list[1]).toEqual({ id: 1, name: 'Council A' })
+    })
+  })
+
+  describe('fetchMessages', () => {
+    it('fetches messages for an authority', async () => {
+      const store = useAuthorityStore()
+      store.init({ public: {} })
+      mockFetchMessages.mockResolvedValue([{ id: 10 }, { id: 11 }])
+
+      const result = await store.fetchMessages(1)
+      expect(result).toEqual([{ id: 10 }, { id: 11 }])
+    })
+  })
+
+  describe('byId getter', () => {
+    it('returns authority by id', () => {
+      const store = useAuthorityStore()
+      store.list[1] = { id: 1, name: 'Council A' }
+      expect(store.byId(1)).toEqual({ id: 1, name: 'Council A' })
+    })
+
+    it('returns undefined for unknown id', () => {
+      const store = useAuthorityStore()
+      expect(store.byId(999)).toBeUndefined()
+    })
+  })
+})

--- a/tests/unit/stores/debug.spec.js
+++ b/tests/unit/stores/debug.spec.js
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+describe('debug store', () => {
+  let useDebugStore
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    setActivePinia(createPinia())
+    const mod = await import('~/stores/debug')
+    useDebugStore = mod.useDebugStore
+  })
+
+  describe('initial state', () => {
+    it('starts with empty logs and enabled', () => {
+      const store = useDebugStore()
+      expect(store.logs).toEqual([])
+      expect(store.enabled).toBe(true)
+    })
+  })
+
+  describe('log', () => {
+    it('adds log entry with timestamp and level', () => {
+      const store = useDebugStore()
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+      store.log('INFO', 'hello')
+      expect(store.logs).toHaveLength(1)
+      expect(store.logs[0].level).toBe('INFO')
+      expect(store.logs[0].message).toBe('hello')
+      expect(store.logs[0].timestamp).toBeDefined()
+      consoleSpy.mockRestore()
+    })
+
+    it('stringifies object arguments', () => {
+      const store = useDebugStore()
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+      store.log('INFO', { key: 'value' })
+      expect(store.logs[0].message).toContain('"key"')
+      expect(store.logs[0].message).toContain('"value"')
+      consoleSpy.mockRestore()
+    })
+
+    it('handles circular objects gracefully', () => {
+      const store = useDebugStore()
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+      const circular = {}
+      circular.self = circular
+
+      store.log('INFO', circular)
+      expect(store.logs).toHaveLength(1)
+      consoleSpy.mockRestore()
+    })
+
+    it('joins multiple arguments with space', () => {
+      const store = useDebugStore()
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+      store.log('INFO', 'hello', 'world')
+      expect(store.logs[0].message).toBe('hello world')
+      consoleSpy.mockRestore()
+    })
+
+    it('caps logs at MAX_LOGS (500)', () => {
+      const store = useDebugStore()
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+      for (let i = 0; i < 510; i++) {
+        store.log('INFO', `msg ${i}`)
+      }
+      expect(store.logs).toHaveLength(500)
+      expect(store.logs[0].message).toBe('msg 10')
+      consoleSpy.mockRestore()
+    })
+
+    it('does nothing when disabled', () => {
+      const store = useDebugStore()
+      store.enabled = false
+
+      store.log('INFO', 'hello')
+      expect(store.logs).toHaveLength(0)
+    })
+
+    it('uses console.error for error level', () => {
+      const store = useDebugStore()
+      const errorSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {})
+
+      store.log('error', 'oops')
+      expect(errorSpy).toHaveBeenCalled()
+      errorSpy.mockRestore()
+    })
+
+    it('uses console.warn for warn level', () => {
+      const store = useDebugStore()
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      store.log('warn', 'careful')
+      expect(warnSpy).toHaveBeenCalled()
+      warnSpy.mockRestore()
+    })
+  })
+
+  describe('convenience methods', () => {
+    it('info logs at INFO level', () => {
+      const store = useDebugStore()
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+      store.info('test')
+      expect(store.logs[0].level).toBe('INFO')
+      consoleSpy.mockRestore()
+    })
+
+    it('warn logs at WARN level', () => {
+      const store = useDebugStore()
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      store.warn('test')
+      expect(store.logs[0].level).toBe('WARN')
+      warnSpy.mockRestore()
+    })
+
+    it('error logs at ERROR level', () => {
+      const store = useDebugStore()
+      const errorSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {})
+
+      store.error('test')
+      expect(store.logs[0].level).toBe('ERROR')
+      errorSpy.mockRestore()
+    })
+
+    it('debug logs at DEBUG level', () => {
+      const store = useDebugStore()
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+      store.debug('test')
+      expect(store.logs[0].level).toBe('DEBUG')
+      consoleSpy.mockRestore()
+    })
+  })
+
+  describe('getLogsAsText getter', () => {
+    it('formats logs as text', () => {
+      const store = useDebugStore()
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+      store.info('first')
+      store.info('second')
+
+      const text = store.getLogsAsText
+      expect(text).toContain('[INFO] first')
+      expect(text).toContain('[INFO] second')
+      expect(text.split('\n')).toHaveLength(2)
+      consoleSpy.mockRestore()
+    })
+  })
+
+  describe('clear', () => {
+    it('removes all logs', () => {
+      const store = useDebugStore()
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+      store.info('test')
+      expect(store.logs).toHaveLength(1)
+
+      store.clear()
+      expect(store.logs).toEqual([])
+      consoleSpy.mockRestore()
+    })
+  })
+})

--- a/tests/unit/stores/domain.spec.js
+++ b/tests/unit/stores/domain.spec.js
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+const mockFetch = vi.fn()
+
+vi.mock('~/api', () => ({
+  default: () => ({
+    domain: {
+      fetch: mockFetch,
+    },
+  }),
+}))
+
+describe('domain store', () => {
+  let useDomainStore
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    setActivePinia(createPinia())
+    const mod = await import('~/stores/domain')
+    useDomainStore = mod.useDomainStore
+  })
+
+  it('fetches domain with params', async () => {
+    const store = useDomainStore()
+    store.init({ public: {} })
+    mockFetch.mockResolvedValue({ domain: 'example.com' })
+
+    const result = await store.fetch({ id: 1 })
+    expect(result).toEqual({ domain: 'example.com' })
+    expect(mockFetch).toHaveBeenCalledWith({ id: 1 })
+  })
+})

--- a/tests/unit/stores/donations.spec.js
+++ b/tests/unit/stores/donations.spec.js
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+const mockFetch = vi.fn()
+const mockAdd = vi.fn()
+const mockStripeIntent = vi.fn()
+const mockStripeSubscription = vi.fn()
+
+vi.mock('~/api', () => ({
+  default: () => ({
+    donations: {
+      fetch: mockFetch,
+      add: mockAdd,
+      stripeIntent: mockStripeIntent,
+      stripeSubscription: mockStripeSubscription,
+    },
+  }),
+}))
+
+describe('donation store', () => {
+  let useDonationStore
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    setActivePinia(createPinia())
+    const mod = await import('~/stores/donations')
+    useDonationStore = mod.useDonationStore
+  })
+
+  describe('initial state', () => {
+    it('starts with default target and zero raised', () => {
+      const store = useDonationStore()
+      expect(store.target).toBe(2000)
+      expect(store.raised).toBe(0)
+    })
+  })
+
+  describe('fetch', () => {
+    it('fetches and stores donation totals', async () => {
+      const store = useDonationStore()
+      store.init({ public: {} })
+      mockFetch.mockResolvedValue({ target: 3000, raised: 1500 })
+
+      await store.fetch(10)
+      expect(store.target).toBe(3000)
+      expect(store.raised).toBe(1500)
+      expect(mockFetch).toHaveBeenCalledWith(10)
+    })
+  })
+
+  describe('add', () => {
+    it('adds donation and returns id', async () => {
+      const store = useDonationStore()
+      store.init({ public: {} })
+      mockAdd.mockResolvedValue({ id: 42 })
+
+      const id = await store.add(1, 50, '2026-01-01')
+      expect(id).toBe(42)
+      expect(mockAdd).toHaveBeenCalledWith(1, 50, '2026-01-01')
+    })
+
+    it('returns undefined when add returns null', async () => {
+      const store = useDonationStore()
+      store.init({ public: {} })
+      mockAdd.mockResolvedValue(null)
+
+      const id = await store.add(1, 50, '2026-01-01')
+      expect(id).toBeUndefined()
+    })
+  })
+
+  describe('stripeIntent', () => {
+    it('creates stripe payment intent', async () => {
+      const store = useDonationStore()
+      store.init({ public: {} })
+      mockStripeIntent.mockResolvedValue({ clientSecret: 'pi_123' })
+
+      const result = await store.stripeIntent({ amount: 1000 })
+      expect(result).toEqual({ clientSecret: 'pi_123' })
+    })
+  })
+
+  describe('stripeSubscription', () => {
+    it('creates stripe subscription', async () => {
+      const store = useDonationStore()
+      store.init({ public: {} })
+      mockStripeSubscription.mockResolvedValue({ subscriptionId: 'sub_123' })
+
+      const result = await store.stripeSubscription(500)
+      expect(result).toEqual({ subscriptionId: 'sub_123' })
+      expect(mockStripeSubscription).toHaveBeenCalledWith(500)
+    })
+  })
+})

--- a/tests/unit/stores/giftaid.spec.js
+++ b/tests/unit/stores/giftaid.spec.js
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+const mockGet = vi.fn()
+const mockSave = vi.fn()
+const mockRemove = vi.fn()
+
+vi.mock('~/api', () => ({
+  default: () => ({
+    giftaid: {
+      get: mockGet,
+      save: mockSave,
+      remove: mockRemove,
+    },
+  }),
+}))
+
+describe('giftaid store', () => {
+  let useGiftAidStore
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    setActivePinia(createPinia())
+    const mod = await import('~/stores/giftaid')
+    useGiftAidStore = mod.useGiftAidStore
+  })
+
+  describe('initial state', () => {
+    it('starts with empty giftaid object', () => {
+      const store = useGiftAidStore()
+      expect(store.giftaid).toEqual({})
+    })
+  })
+
+  describe('fetch', () => {
+    it('fetches and stores giftaid data', async () => {
+      const store = useGiftAidStore()
+      store.init({ public: {} })
+      mockGet.mockResolvedValue({ name: 'Alice', postcode: 'SW1A 1AA' })
+
+      const result = await store.fetch()
+      expect(result).toEqual({ name: 'Alice', postcode: 'SW1A 1AA' })
+      expect(store.giftaid).toEqual({ name: 'Alice', postcode: 'SW1A 1AA' })
+    })
+
+    it('defaults to empty object when API returns null', async () => {
+      const store = useGiftAidStore()
+      store.init({ public: {} })
+      mockGet.mockResolvedValue(null)
+
+      const result = await store.fetch()
+      expect(result).toEqual({})
+      expect(store.giftaid).toEqual({})
+    })
+  })
+
+  describe('save', () => {
+    it('saves current giftaid state', async () => {
+      const store = useGiftAidStore()
+      store.init({ public: {} })
+      store.giftaid = { name: 'Bob' }
+
+      await store.save()
+      expect(mockSave).toHaveBeenCalledWith({ name: 'Bob' })
+    })
+  })
+
+  describe('remove', () => {
+    it('calls API remove', async () => {
+      const store = useGiftAidStore()
+      store.init({ public: {} })
+
+      await store.remove()
+      expect(mockRemove).toHaveBeenCalled()
+    })
+  })
+})

--- a/tests/unit/stores/image.spec.js
+++ b/tests/unit/stores/image.spec.js
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+const mockPost = vi.fn()
+
+vi.mock('~/api', () => ({
+  default: () => ({
+    image: {
+      post: mockPost,
+    },
+  }),
+}))
+
+describe('image store', () => {
+  let useImageStore
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    setActivePinia(createPinia())
+    const mod = await import('~/stores/image')
+    useImageStore = mod.useImageStore
+  })
+
+  it('posts image data', async () => {
+    const store = useImageStore()
+    store.init({ public: {} })
+    mockPost.mockResolvedValue({ id: 1 })
+
+    const result = await store.post({ file: 'data' })
+    expect(result).toEqual({ id: 1 })
+    expect(mockPost).toHaveBeenCalledWith({ file: 'data' })
+  })
+
+  it('rates image recognition', async () => {
+    const store = useImageStore()
+    store.init({ public: {} })
+    mockPost.mockResolvedValue({})
+
+    await store.rateRecognise(42, 'good')
+    expect(mockPost).toHaveBeenCalledWith({ id: 42, raterecognise: 'good' })
+  })
+})

--- a/tests/unit/stores/location.spec.js
+++ b/tests/unit/stores/location.spec.js
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+const mockFetch = vi.fn()
+const mockTypeahead = vi.fn()
+const mockLatlng = vi.fn()
+const mockFetchv2 = vi.fn()
+const mockDel = vi.fn()
+const mockAdd = vi.fn()
+const mockUpdate = vi.fn()
+const mockConvertKML = vi.fn()
+
+vi.mock('~/api', () => ({
+  default: () => ({
+    location: {
+      fetch: mockFetch,
+      typeahead: mockTypeahead,
+      latlng: mockLatlng,
+      fetchv2: mockFetchv2,
+      del: mockDel,
+      add: mockAdd,
+      update: mockUpdate,
+      convertKML: mockConvertKML,
+    },
+  }),
+}))
+
+describe('location store', () => {
+  let useLocationStore
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    setActivePinia(createPinia())
+    const mod = await import('~/stores/location')
+    useLocationStore = mod.useLocationStore
+  })
+
+  describe('initial state', () => {
+    it('starts with empty list', () => {
+      const store = useLocationStore()
+      expect(store.list).toEqual({})
+    })
+  })
+
+  describe('fetch', () => {
+    it('returns full response when locations array present', async () => {
+      const store = useLocationStore()
+      store.init({ public: {} })
+      const response = { locations: [{ id: 1 }, { id: 2 }] }
+      mockFetch.mockResolvedValue(response)
+
+      const result = await store.fetch({ id: 1 })
+      expect(result).toEqual(response)
+    })
+
+    it('returns single location when response has location property', async () => {
+      const store = useLocationStore()
+      store.init({ public: {} })
+      mockFetch.mockResolvedValue({ location: { id: 1, name: 'Test' } })
+
+      const result = await store.fetch({ id: 1 })
+      expect(result).toEqual({ id: 1, name: 'Test' })
+    })
+
+    it('returns locations property when no locations array and no single location', async () => {
+      const store = useLocationStore()
+      store.init({ public: {} })
+      mockFetch.mockResolvedValue({ other: 'data' })
+
+      const result = await store.fetch({ id: 1 })
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe('typeahead', () => {
+    it('returns typeahead results', async () => {
+      const store = useLocationStore()
+      store.init({ public: {} })
+      mockTypeahead.mockResolvedValue([{ id: 1, name: 'London' }])
+
+      const result = await store.typeahead('Lon')
+      expect(result).toEqual([{ id: 1, name: 'London' }])
+    })
+  })
+
+  describe('fetchByLatLng', () => {
+    it('fetches location by coordinates', async () => {
+      const store = useLocationStore()
+      store.init({ public: {} })
+      mockLatlng.mockResolvedValue({ id: 1, name: 'Nearby' })
+
+      const result = await store.fetchByLatLng(51.5, -0.1)
+      expect(result).toEqual({ id: 1, name: 'Nearby' })
+      expect(mockLatlng).toHaveBeenCalledWith(51.5, -0.1)
+    })
+  })
+
+  describe('fetchv2', () => {
+    it('fetches and caches location', async () => {
+      const store = useLocationStore()
+      store.init({ public: {} })
+      mockFetchv2.mockResolvedValue({ id: 1, name: 'Test' })
+
+      const result = await store.fetchv2(1)
+      expect(result).toEqual({ id: 1, name: 'Test' })
+      expect(store.list[1]).toEqual({ id: 1, name: 'Test' })
+    })
+
+    it('handles null response', async () => {
+      const store = useLocationStore()
+      store.init({ public: {} })
+      mockFetchv2.mockResolvedValue(null)
+
+      const result = await store.fetchv2(1)
+      expect(result).toBeNull()
+      expect(store.list[1]).toBeUndefined()
+    })
+  })
+
+  describe('delete', () => {
+    it('deletes location and removes from list', async () => {
+      const store = useLocationStore()
+      store.init({ public: {} })
+      store.list[1] = { id: 1, name: 'Test' }
+      mockDel.mockResolvedValue({})
+
+      await store.delete({ id: 1, groupid: 5 })
+      expect(mockDel).toHaveBeenCalledWith(1, 5)
+      expect(store.list[1]).toBeUndefined()
+    })
+  })
+
+  describe('add', () => {
+    it('adds location and returns id', async () => {
+      const store = useLocationStore()
+      store.init({ public: {} })
+      mockAdd.mockResolvedValue({ id: 42 })
+
+      const id = await store.add({ name: 'New', groupid: 5 })
+      expect(id).toBe(42)
+    })
+  })
+
+  describe('update', () => {
+    it('calls API update', async () => {
+      const store = useLocationStore()
+      store.init({ public: {} })
+      mockUpdate.mockResolvedValue({})
+
+      await store.update({ id: 1, name: 'Updated' })
+      expect(mockUpdate).toHaveBeenCalledWith({ id: 1, name: 'Updated' })
+    })
+  })
+
+  describe('convertKML', () => {
+    it('converts KML to WKT', async () => {
+      const store = useLocationStore()
+      store.init({ public: {} })
+      mockConvertKML.mockResolvedValue({ wkt: 'POLYGON(...)' })
+
+      const result = await store.convertKML('<kml>...</kml>')
+      expect(result).toBe('POLYGON(...)')
+    })
+  })
+
+  describe('byId getter', () => {
+    it('returns location by id', () => {
+      const store = useLocationStore()
+      store.list[1] = { id: 1, name: 'Test' }
+      expect(store.byId(1)).toEqual({ id: 1, name: 'Test' })
+    })
+
+    it('returns undefined for unknown id', () => {
+      const store = useLocationStore()
+      expect(store.byId(999)).toBeUndefined()
+    })
+  })
+})

--- a/tests/unit/stores/loggingContext.spec.js
+++ b/tests/unit/stores/loggingContext.spec.js
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+vi.mock('~/composables/useTrace', () => ({
+  getSessionId: vi.fn(() => 'session-abc'),
+}))
+
+describe('loggingContext store', () => {
+  let useLoggingContextStore
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    setActivePinia(createPinia())
+    const mod = await import('~/stores/loggingContext')
+    useLoggingContextStore = mod.useLoggingContextStore
+  })
+
+  describe('initial state', () => {
+    it('starts with null values and empty modal stack', () => {
+      const store = useLoggingContextStore()
+      expect(store.pageId).toBeNull()
+      expect(store.pageUrl).toBeNull()
+      expect(store.pageTitle).toBeNull()
+      expect(store.modalStack).toEqual([])
+      expect(store.site).toBeNull()
+    })
+  })
+
+  describe('init', () => {
+    it('sets site from runtime config', () => {
+      const store = useLoggingContextStore()
+      store.init({ public: { SITE: 'MT' } })
+      expect(store.site).toBe('MT')
+    })
+
+    it('defaults site to FD when not specified', () => {
+      const store = useLoggingContextStore()
+      store.init({ public: {} })
+      expect(store.site).toBe('FD')
+    })
+  })
+
+  describe('startPage', () => {
+    it('sets page id and url from route', () => {
+      const store = useLoggingContextStore()
+      store.startPage({ path: '/chats/42' })
+
+      expect(store.pageId).toMatch(/^page_/)
+      expect(store.pageUrl).toBe('/chats/42')
+      expect(store.modalStack).toEqual([])
+    })
+
+    it('clears modal stack on new page', () => {
+      const store = useLoggingContextStore()
+      store.modalStack = [{ id: 'modal_1', name: 'test' }]
+
+      store.startPage({ path: '/home' })
+      expect(store.modalStack).toEqual([])
+    })
+  })
+
+  describe('pushModal / popModal', () => {
+    it('pushes modal with generated id', () => {
+      const store = useLoggingContextStore()
+      const id = store.pushModal('ChatModal')
+
+      expect(id).toMatch(/^modal_/)
+      expect(store.modalStack).toHaveLength(1)
+      expect(store.modalStack[0].name).toBe('ChatModal')
+    })
+
+    it('pops most recent modal', () => {
+      const store = useLoggingContextStore()
+      const id1 = store.pushModal('First')
+      store.pushModal('Second')
+
+      const popped = store.popModal()
+      expect(store.modalStack).toHaveLength(1)
+      expect(store.modalStack[0].id).toBe(id1)
+      expect(popped).toMatch(/^modal_/)
+    })
+
+    it('returns undefined when popping empty stack', () => {
+      const store = useLoggingContextStore()
+      const result = store.popModal()
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe('getHeaders', () => {
+    it('returns headers with session and page info', () => {
+      const store = useLoggingContextStore()
+      store.init({ public: { SITE: 'MT' } })
+      store.startPage({ path: '/home' })
+
+      const headers = store.getHeaders()
+      expect(headers['X-Freegle-Session']).toBe('session-abc')
+      expect(headers['X-Freegle-Page']).toMatch(/^page_/)
+      expect(headers['X-Freegle-Modal']).toBe('')
+      expect(headers['X-Freegle-Site']).toBe('MT')
+    })
+
+    it('includes comma-separated modal ids', () => {
+      const store = useLoggingContextStore()
+      const id1 = store.pushModal('First')
+      const id2 = store.pushModal('Second')
+
+      const headers = store.getHeaders()
+      expect(headers['X-Freegle-Modal']).toBe(`${id1},${id2}`)
+    })
+  })
+
+  describe('getContext', () => {
+    it('returns full context object', () => {
+      const store = useLoggingContextStore()
+      store.init({ public: { SITE: 'FD' } })
+      store.startPage({ path: '/browse' })
+      store.pushModal('TestModal')
+
+      const ctx = store.getContext()
+      expect(ctx.session_id).toBe('session-abc')
+      expect(ctx.page_id).toMatch(/^page_/)
+      expect(ctx.page_url).toBe('/browse')
+      expect(ctx.site).toBe('FD')
+      expect(ctx.modal_stack).toHaveLength(1)
+      expect(ctx.modal_names).toEqual(['TestModal'])
+    })
+  })
+})

--- a/tests/unit/stores/logo.spec.js
+++ b/tests/unit/stores/logo.spec.js
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+const mockFetch = vi.fn()
+
+vi.mock('~/api', () => ({
+  default: () => ({
+    logo: {
+      fetch: mockFetch,
+    },
+  }),
+}))
+
+describe('logo store', () => {
+  let useLogoStore
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    setActivePinia(createPinia())
+    const mod = await import('~/stores/logo')
+    useLogoStore = mod.useLogoStore
+  })
+
+  it('fetches logo with params', async () => {
+    const store = useLogoStore()
+    store.init({ public: {} })
+    mockFetch.mockResolvedValue({ url: 'https://example.com/logo.png' })
+
+    const result = await store.fetch({ groupid: 5 })
+    expect(result).toEqual({ url: 'https://example.com/logo.png' })
+    expect(mockFetch).toHaveBeenCalledWith({ groupid: 5 })
+  })
+})

--- a/tests/unit/stores/microvolunteering.spec.js
+++ b/tests/unit/stores/microvolunteering.spec.js
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+const mockChallenge = vi.fn()
+const mockResponse = vi.fn()
+const mockFetch = vi.fn()
+
+vi.mock('~/api', () => ({
+  default: () => ({
+    microvolunteering: {
+      challenge: mockChallenge,
+      response: mockResponse,
+      fetch: mockFetch,
+    },
+  }),
+}))
+
+describe('microvolunteering store', () => {
+  let useMicroVolunteeringStore
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    setActivePinia(createPinia())
+    const mod = await import('~/stores/microvolunteering')
+    useMicroVolunteeringStore = mod.useMicroVolunteeringStore
+  })
+
+  describe('initial state', () => {
+    it('starts with empty list', () => {
+      const store = useMicroVolunteeringStore()
+      expect(store.list).toEqual({})
+    })
+  })
+
+  describe('challenge', () => {
+    it('fetches challenge item and stores it', async () => {
+      const store = useMicroVolunteeringStore()
+      store.init({ public: {} })
+      mockChallenge.mockResolvedValue({ id: 1, type: 'SearchTerm' })
+
+      const result = await store.challenge(['SearchTerm'])
+      expect(result).toEqual({ id: 1, type: 'SearchTerm' })
+      expect(store.list[1]).toEqual({ id: 1, type: 'SearchTerm' })
+    })
+
+    it('handles null response', async () => {
+      const store = useMicroVolunteeringStore()
+      store.init({ public: {} })
+      mockChallenge.mockResolvedValue(null)
+
+      const result = await store.challenge(['SearchTerm'])
+      expect(result).toBeNull()
+      expect(Object.keys(store.list)).toHaveLength(0)
+    })
+  })
+
+  describe('respond', () => {
+    it('sends response', async () => {
+      const store = useMicroVolunteeringStore()
+      store.init({ public: {} })
+      mockResponse.mockResolvedValue({})
+
+      await store.respond({ id: 1, response: 'yes' })
+      expect(mockResponse).toHaveBeenCalledWith({ id: 1, response: 'yes' })
+    })
+  })
+
+  describe('fetch', () => {
+    it('fetches and stores microvolunteerings', async () => {
+      const store = useMicroVolunteeringStore()
+      store.init({ public: {} })
+      mockFetch.mockResolvedValue({
+        context: { total: 2 },
+        microvolunteerings: [
+          { id: 1, type: 'A' },
+          { id: 2, type: 'B' },
+        ],
+      })
+
+      const context = await store.fetch({ limit: 10 })
+      expect(context).toEqual({ total: 2 })
+      expect(store.list[1]).toEqual({ id: 1, type: 'A' })
+      expect(store.list[2]).toEqual({ id: 2, type: 'B' })
+    })
+  })
+
+  describe('clearOne', () => {
+    it('removes a single item', () => {
+      const store = useMicroVolunteeringStore()
+      store.list[1] = { id: 1 }
+      store.list[2] = { id: 2 }
+
+      store.clearOne(1)
+      expect(store.list[1]).toBeUndefined()
+      expect(store.list[2]).toBeDefined()
+    })
+  })
+
+  describe('clear', () => {
+    it('resets list to empty', () => {
+      const store = useMicroVolunteeringStore()
+      store.list[1] = { id: 1 }
+
+      store.clear()
+      expect(store.list).toEqual({})
+    })
+  })
+
+  describe('byId getter', () => {
+    it('returns item by id', () => {
+      const store = useMicroVolunteeringStore()
+      store.list[1] = { id: 1, type: 'SearchTerm' }
+      expect(store.byId(1)).toEqual({ id: 1, type: 'SearchTerm' })
+    })
+
+    it('returns undefined for unknown id', () => {
+      const store = useMicroVolunteeringStore()
+      expect(store.byId(999)).toBeUndefined()
+    })
+  })
+})

--- a/tests/unit/stores/search.spec.js
+++ b/tests/unit/stores/search.spec.js
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+const mockFetch = vi.fn()
+const mockDel = vi.fn()
+
+vi.mock('~/api', () => ({
+  default: () => ({
+    usersearch: {
+      fetch: mockFetch,
+      del: mockDel,
+    },
+  }),
+}))
+
+describe('search store', () => {
+  let useSearchStore
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    setActivePinia(createPinia())
+    const mod = await import('~/stores/search')
+    useSearchStore = mod.useSearchStore
+  })
+
+  describe('initial state', () => {
+    it('starts with empty list and no fetching', () => {
+      const store = useSearchStore()
+      expect(store.list).toEqual([])
+      expect(store.fetching).toBeNull()
+    })
+  })
+
+  describe('fetch', () => {
+    it('fetches searches for a user', async () => {
+      const store = useSearchStore()
+      store.init({ public: {} })
+      mockFetch.mockResolvedValue([{ id: 1, term: 'books' }])
+
+      await store.fetch(42)
+      expect(store.list).toEqual([{ id: 1, term: 'books' }])
+      expect(mockFetch).toHaveBeenCalledWith(42)
+    })
+
+    it('deduplicates concurrent fetches', async () => {
+      const store = useSearchStore()
+      store.init({ public: {} })
+
+      let resolveFirst
+      mockFetch.mockReturnValueOnce(
+        new Promise((r) => {
+          resolveFirst = r
+        })
+      )
+
+      const f1 = store.fetch(42)
+      const f2 = store.fetch(42)
+
+      resolveFirst([{ id: 1 }])
+      await f1
+      await f2
+
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('delete', () => {
+    it('deletes search and refetches', async () => {
+      const store = useSearchStore()
+      store.init({ public: {} })
+      mockDel.mockResolvedValue({})
+      mockFetch.mockResolvedValue([])
+
+      await store.delete(1, 42)
+      expect(mockDel).toHaveBeenCalledWith(1)
+      expect(mockFetch).toHaveBeenCalledWith(42)
+    })
+  })
+
+  describe('get getter', () => {
+    it('finds search by id', () => {
+      const store = useSearchStore()
+      store.list = [
+        { id: 1, term: 'books' },
+        { id: 2, term: 'chairs' },
+      ]
+      expect(store.get(2)).toEqual({ id: 2, term: 'chairs' })
+    })
+
+    it('returns undefined for unknown id', () => {
+      const store = useSearchStore()
+      store.list = [{ id: 1 }]
+      expect(store.get(999)).toBeUndefined()
+    })
+  })
+})

--- a/tests/unit/stores/stats.spec.js
+++ b/tests/unit/stores/stats.spec.js
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+const mockDashboardFetch = vi.fn()
+const mockFetchHeatmap = vi.fn()
+
+vi.mock('~/api', () => ({
+  default: () => ({
+    dashboard: {
+      fetch: mockDashboardFetch,
+      fetchHeatmap: mockFetchHeatmap,
+    },
+  }),
+}))
+
+describe('stats store', () => {
+  let useStatsStore
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    setActivePinia(createPinia())
+    const mod = await import('~/stores/stats')
+    useStatsStore = mod.useStatsStore
+  })
+
+  describe('initial state', () => {
+    it('starts with empty heatmap', () => {
+      const store = useStatsStore()
+      expect(store.heatmap).toEqual({})
+    })
+  })
+
+  describe('fetch', () => {
+    it('spreads fetched stats onto store', async () => {
+      const store = useStatsStore()
+      store.init({ public: {} })
+      mockDashboardFetch.mockResolvedValue({
+        ApprovedMessageCount: 100,
+        Weight: 5000,
+      })
+
+      await store.fetch({ groupid: 1 })
+      expect(store.ApprovedMessageCount).toBe(100)
+      expect(store.Weight).toBe(5000)
+    })
+  })
+
+  describe('fetchHeatmap', () => {
+    it('fetches and stores heatmap data', async () => {
+      const store = useStatsStore()
+      store.init({ public: {} })
+      const heatmapData = { points: [{ lat: 51.5, lng: -0.1, count: 10 }] }
+      mockFetchHeatmap.mockResolvedValue(heatmapData)
+
+      const result = await store.fetchHeatmap()
+      expect(result).toEqual(heatmapData)
+      expect(store.heatmap).toEqual(heatmapData)
+    })
+  })
+
+  describe('clear', () => {
+    it('resets store to initial state', async () => {
+      const store = useStatsStore()
+      store.init({ public: {} })
+      store.heatmap = { points: [1, 2, 3] }
+
+      store.clear()
+      expect(store.heatmap).toEqual({})
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Adds unit tests for all 12 remaining untested Pinia stores
- domain (1), logo (1), image (2), giftaid (5), stats (4), authority (5), donations (7), search (6), microvolunteering (8), location (13), debug (16), loggingContext (11)
- 79 new tests total, all passing (11511✓ 3✗ — 3 pre-existing failures unrelated)

## Test plan
- [x] All 79 new tests pass locally
- [ ] CI green
